### PR TITLE
Update homepage job title text

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -63,7 +63,7 @@ const logos = [
           Builder CIO. I bring AI out of the lab and into operations.
         </p>
         <p class="mt-4 text-lg font-normal leading-relaxed text-gray-500 dark:text-gray-400 max-w-2xl mx-auto italic">
-          Global CIO at Pax8. Founder at 1310. Technology leader with Linux and networking roots.
+          SVP Workflow Engineering at Pax8. Founder at 1310. Technology leader with Linux and networking roots.
         </p>
         <div class="mt-10 flex items-center justify-center gap-x-6">
           <Button href="https://linkedin.com/in/simonjgreen" size="lg">


### PR DESCRIPTION
## Summary
- update the homepage hero subtitle to reflect the new Pax8 job title

## Testing
- npm run dev -- --host 0.0.0.0 --port 4321

------
https://chatgpt.com/codex/tasks/task_e_68e2198c8b148329a1de2fe69745e6cf