### PR TITLE
Add 7-day cooldown to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       astro:
         patterns:
@@ -27,3 +29,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Add `cooldown: default-days: 7` to both npm and github-actions ecosystems
- Dependabot will wait 7 days after a package is published before opening a PR, reducing noise from yanked or quickly-patched releases

## Test plan
- [x] Verify Dependabot config is valid (next scheduled run)