### PR TITLE
Add post: “No, your Agent Skill is not automation”

### DIFF
--- a/src/content/posts/no-your-agent-skill-is-not-automation.mdx
+++ b/src/content/posts/no-your-agent-skill-is-not-automation.mdx
@@ -1,0 +1,257 @@
+---
+title: "No, your Agent Skill is not automation"
+description: "Agent Skills and AI coworkers create real leverage, but personal productivity gains are not the same as operational automation."
+date: 2026-05-27
+tags: ["ai", "automation", "agents", "operations", "workflow"]
+---
+
+There is a particular moment in every technology adoption curve where the language gets sloppy.
+
+We discover something powerful. It changes how fast we can work. It makes previously tedious jobs feel lightweight. It gives individuals the sense that they suddenly have a team behind them. And because the experience feels so transformative, we reach for bigger words than the thing has earned.
+
+Right now, one of those words is automation.
+
+Claude Cowork and Agent Skills are creating exactly this moment. They are genuinely impressive. Anthropic describes Cowork as goal-driven assistance that can work across your computer, files, and apps to return a finished deliverable ([Anthropic: Claude Cowork](https://www.anthropic.com/product/claude-cowork)). For many knowledge workers, Cowork is the first AI tool that feels less like a chat window and more like a colleague: “analyse this folder”, “turn these notes into a report”, “find the pattern in this data”, “prepare the briefing pack”, “apply the way I like this done and do it again next time.”
+
+Agent Skills amplify that feeling. Anthropic defines them as modular capabilities that package instructions, metadata, and optional resources such as scripts and templates ([Agent Skills overview](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)). In practical terms, Skills are folders of instructions, scripts, and resources Claude can load when needed ([agentskills.io](https://agentskills.io/home)). They let people capture reusable instructions, templates, preferences, scripts, and domain knowledge so that Claude can repeat a familiar type of work more consistently. The result can feel like discovering a cheat code for knowledge work. You teach the machine once, and suddenly it can help you achieve the same outcome again.
+
+That is a big deal.
+
+But it is not the same thing as automation.
+
+And if we confuse the two, we will make bad operating decisions.
+
+## The difference between personal leverage and operational automation
+
+An Agent Skill is a shortcut. A pattern. Claude only accesses a Skill when it is relevant to the task at hand, rather than executing it like a fixed always-on workflow ([Claude blog: Skills](https://claude.com/blog/skills)). A reusable way of helping an AI perform a task in a familiar style or against a familiar standard. It can encode expertise. It can reduce prompting effort. It can improve consistency. It can make a good knowledge worker dramatically more effective.
+
+Claude Cowork is similarly powerful. It can help someone execute multi-step knowledge work across files, documents, tools, and context. It can take work that would once have required hours of manual stitching and compress it into a much smaller amount of human effort.
+
+But most of the time, this is still personal leverage.
+
+It is not yet operational automation.
+
+That distinction matters because personal leverage and automation affect the cost curve in different ways.
+
+Personal leverage makes an individual more productive. It lets one person do more. It may make them feel like they have the strength of five people, or ten people, depending on the task. That is valuable. It should be encouraged. Everyone should have access to tools that make them more capable.
+
+But the operating model still depends on the person.
+
+The work still routes through their judgement, their access, their attention, their local context, their prompt discipline, their calendar, their tolerance for risk, and often their identity. If more work arrives, you still need more human supervision. If the process grows, the bottleneck moves but does not disappear. If the person is overloaded, quality falls. If they leave, the “process” may leave with them.
+
+That is not automation. That is a better tool in the hands of a human operator.
+
+Automation is different. Automation is when the process keeps flowing without scaling the human in the loop. It is when the operating cost is no longer directly coupled to the volume of the outcome. It is when the machine runs the routine path, handles the expected cases, records what happened, escalates exceptions, and does so without needing a named person to constantly supervise its every move.
+
+Agent Skills can help you get there.
+
+Claude Cowork can help you discover, design, prototype, and improve the path.
+
+But they are not the destination.
+
+## The curve has moved, but it has not changed shape
+
+A lot of organisations scale work by throwing people at it. More tickets? Add people. More reports? Add analysts. More manual checks? Add operations headcount. More customers? Add more process coordinators.
+
+That model has a roughly linear scaling problem. Output goes up when people go up. Cost goes up when people go up. Complexity goes up when people go up.
+
+AI assistance changes the experience of that curve. It can make each person more productive, sometimes dramatically. A person with good AI tooling can burn through work that used to require a small team. That feels like a structural breakthrough.
+
+But often it is only a one-time adjustment.
+
+The line moves up. The individual’s throughput improves. The organisation gets more output for the same headcount.
+
+Then the old pattern resumes.
+
+The department still scales through people. The team still depends on human attention. The process still waits for approvals, reviews, corrections, clarifications, and decisions. The AI-generated output still needs someone to read it, trust it, fix it, route it, and own it.
+
+That is not a new operating model. It is a higher-performing version of the old one.
+
+Deterministic automation is what changes the shape of the curve. It decouples routine output from human capacity. It means the thousandth execution does not require the thousandth unit of human attention. It means the process does not get tired, distracted, buried in Slack, pulled into meetings, or quietly deprioritised because the person who understands it is on holiday.
+
+This is why tools like n8n and Power Automate are not made obsolete by Claude Cowork. They solve a different class of problem: persistent, orchestrated workflow automation across systems, triggers, data, and business processes. n8n describes itself as a workflow automation tool that combines AI capabilities with business process automation, and defines workflows as connected nodes that automate a process ([n8n docs](https://docs.n8n.io/), [n8n workflows](https://docs.n8n.io/workflows/)). Microsoft positions Power Automate as an end-to-end enterprise automation solution ([Power Automate](https://www.microsoft.com/en-us/power-platform/products/power-automate)).
+
+Claude Cowork may help you design the workflow. It may help you write the requirements. It may help you analyse the exceptions. It may even help generate parts of the implementation.
+
+But the automation layer still matters.
+
+## Non-determinism is not a rounding error
+
+One of the uncomfortable truths about AI-assisted work is that it retains a lot of human fallibility while making it look more polished.
+
+A human can misunderstand the task. So can an AI.
+
+A human can miss an edge case. So can an AI.
+
+A human can make assumptions from incomplete context. So can an AI.
+
+A human can sound confident while being wrong. AI is spectacularly good at that, and Anthropic explicitly notes that even advanced models can still produce factually incorrect or context-inconsistent output ([Reduce hallucinations](https://platform.claude.com/docs/en/test-and-evaluate/strengthen-guardrails/reduce-hallucinations)).
+
+Agent Skills can reduce this problem, but they do not eliminate it. Even low-temperature usage is not a guarantee of identical outputs, so model behavior should not be treated as deterministic logic ([Model migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide)). A skill can encode a preferred method. It can provide templates, examples, instructions, and checks. It can make the AI more likely to behave in the desired way. But unless the process is engineered with validation, tests, control points, observability, and exception handling, you are still relying on a probabilistic system producing outputs that may vary from run to run.
+
+That might be fine for personal productivity.
+
+It is not fine to pretend it is the same as deterministic automation.
+
+In a deterministic automated process, the same input under the same conditions should produce the same outcome, or at least follow the same clearly defined decision path. Where variability exists, it should be bounded, logged, monitored, and explainable. Failure should be designed. Exceptions should be routed. Permissions should be explicit. Ownership should be clear. The process should have a lifecycle beyond the person who first created it.
+
+With AI-assisted work, especially when executed under a user’s identity, the boundary can become fuzzy. Did the human do the work? Did the AI do the work? Was the decision made by the person, suggested by the model, or implicitly accepted because the output looked plausible? What controls were applied? What happens if the model chooses a different path next time?
+
+These questions are not bureaucracy. They are the difference between a productivity trick and a business process.
+
+## “Human in the loop” should be treated as a metric
+
+“Human in the loop” has become one of the default phrases of the post-GPT world. It is usually used as a reassurance. Do not worry, the AI is not fully autonomous. There is still a human in the loop.
+
+That is useful for risk.
+
+It is less useful for scale.
+
+For operating model design, human-in-the-loop should be treated as a measurable constraint. How much human involvement is required for this task to complete successfully? Is the human initiating the work, supervising the work, approving the work, correcting the work, or merely handling exceptions? How often does the process stop and wait for a person? How much judgement is genuinely required, and how much is just inherited habit?
+
+A department with a high human-in-the-loop requirement is not autonomous. It may be AI-enabled. It may be more productive than it was. But it is still constrained by human throughput.
+
+That is not a moral failing. Many tasks should have human judgement. Some decisions need accountability, empathy, context, or commercial sensitivity. The goal is not to remove humans from everything.
+
+The goal is to be honest about where humans are actually required.
+
+If a human must inspect every AI output before anything can happen, you have not automated the task. You have created a next-generation Word processor. A very good one, perhaps. A magical one. A Word processor that can draft, analyse, summarise, reason, and suggest.
+
+But still a Word processor.
+
+## From org chart to Work Chart
+
+Microsoft’s Work Chart idea is useful because it encourages leaders to stop thinking only in terms of reporting lines and start thinking in terms of work. Microsoft describes the shift as moving from a traditional org chart to a dynamic, outcome-driven Work Chart ([Work Trend Index](https://www.microsoft.com/en-us/worklab/work-trend-index/2025-the-year-the-frontier-firm-is-born)). What outcomes need to happen? What tasks compose those outcomes? Which tasks are done by humans, which by AI agents, and which by deterministic systems? Where does judgement sit? Where does execution sit? Where does accountability sit?
+
+That is a better mental model than the traditional org chart for AI-enabled organisations.
+
+But it only works if we are precise.
+
+A Work Chart that simply maps every task to “Sarah plus Claude” or “Finance analyst plus Agent Skill” is not a transformed operating model. It is an org chart with better stationery. The work is still bound to named people. The process still depends on their attention. The business still scales by increasing individual load until the next bottleneck appears.
+
+A useful Work Chart should expose the human-in-the-loop requirement for every task.
+
+For each task, ask:
+
+- Does this require human judgement every time, or only when something unusual happens?
+- Does the process run on a trigger, or does someone have to remember to start it?
+- Does it execute through a named user’s credentials, or through a governed service identity?
+- Are the inputs and outputs structured?
+- Is there validation?
+- Is there an audit trail?
+- What happens when the AI is wrong?
+- What happens when the human is unavailable?
+- What happens when volume doubles?
+- Who owns the process after the person who invented the skill moves role?
+
+These are the questions that separate AI theatre from operational design.
+
+## The blast radius of the AI-augmented individual
+
+One of the most under-discussed risks of personal AI leverage is blast radius.
+
+When a person becomes dramatically more productive, the organisation tends to route more work through them. That feels efficient. They are the person who knows how to get things done. They have the best prompts. They have the Agent Skills. They understand how to make Cowork dance. They become the internal wizard.
+
+This is flattering. It is also dangerous.
+
+The more throughput an individual carries, the greater the operational dependency on that individual. If they are tired, quality drops. If they are overwhelmed, things get missed. If they are distracted, the AI’s mistakes may pass through unchecked. If they leave, nobody knows whether their way of working was a repeatable process, a set of local files, a collection of prompts, or a private habit.
+
+There is also an identity problem. If the AI works under the user’s identity, it inherits the user’s permissions and acts in the user’s operational context. Anthropic’s connector guidance is explicit that connecting a service grants Claude permission to access and potentially modify data based on account permissions ([Claude connectors support](https://support.claude.com/en/articles/11176164-use-connectors-to-extend-claude-s-capabilities)). That may be perfectly reasonable for personal productivity. But it is a poor substitute for a governed process. A business-critical workflow should not depend on whether one person’s laptop is open, whether their account still has access, or whether their personal AI setup is intact.
+
+The question is not “can this person do ten times more?”
+
+The question is “should the organisation depend on this person doing ten times more?”
+
+Those are very different questions.
+
+## The right mental model
+
+A better way to think about this is in levels.
+
+At level one, the human does the task manually. This is traditional knowledge work.
+
+At level two, the human uses AI to go faster. This is assisted productivity.
+
+At level three, the human uses reusable Agent Skills or Claude Cowork workflows to make repeated tasks easier and more consistent. This is structured personal leverage.
+
+At level four, the task is orchestrated through a workflow platform, with triggers, system permissions, validation, retries, logging, and exception handling. In Microsoft’s ecosystem, even ownership is a first-order design choice: flows can be owned by a service principal or a user account, which affects stability, security, and compliance ([Power Automate ownership guidance](https://learn.microsoft.com/en-us/power-automate/guidance/coding-guidelines/understand-access-to-flows)). The human supervises exceptions rather than every execution. This is operational automation.
+
+At level five, the process is continuously monitored and improved, with clear ownership, measurable performance, and humans focused on policy, design, judgement, and edge cases. This is a mature automated operating model.
+
+Most organisations are currently celebrating levels two and three as if they were level four.
+
+That is the mistake.
+
+Levels two and three are valuable. They create adoption. They reveal patterns. They help teams understand which tasks are repeatable. They uncover automation opportunities. They make employees more capable and often happier. They are a necessary part of the journey.
+
+But they are not the same as durable automation.
+
+## What leaders should do instead
+
+The answer is not to slow down AI adoption. Quite the opposite.
+
+Give everyone access to these tools. Encourage experimentation. Let people build Agent Skills. Let them use Claude Cowork to attack the tedious, repetitive, high-friction work that clogs the week. Celebrate the people who find better ways to produce good outcomes.
+
+But do not stop there.
+
+Treat personal AI workflows as discovery mechanisms. When someone builds a useful Agent Skill, ask whether they have found a candidate for automation. When Cowork helps someone perform a task repeatedly, ask whether the task should be moved into a governed workflow. When a team starts relying on one person’s AI-assisted process, ask how to make that process independent of the individual.
+
+The path should be:
+
+discover with AI assistance, standardise with shared practice, industrialise with automation.
+
+Agent Skills are excellent for the first two stages. Claude Cowork is excellent for helping people cross the gap between intention and execution. But business-critical, high-volume, repeatable work needs more than an intelligent assistant. It needs engineered flow.
+
+It needs triggers.
+
+It needs queues.
+
+It needs retries.
+
+It needs observability. Real automation operations require audit and runtime monitoring of runs, failures, and action-level details ([Power Platform audit logging](https://learn.microsoft.com/en-us/power-platform/admin/activity-logging-auditing/activity-logs-power-automate)).
+
+It needs permission boundaries.
+
+It needs exception handling.
+
+It needs tests.
+
+It needs ownership.
+
+It needs to run when the person who invented it is asleep, on holiday, promoted, distracted, or gone.
+
+## Do not hand the factory to the intern
+
+The best metaphor for today’s AI tools is still the ultra-smart, hyper-confident intern.
+
+This intern is astonishing. It can read fast, write fast, summarise fast, draft fast, analyse fast, and connect ideas that would take a person much longer to assemble. It can be a phenomenal force multiplier. Every knowledge worker should learn how to use it.
+
+But you would not hand the intern the keys to the factory and call that automation.
+
+You would not let it quietly operate every process through a senior employee’s badge and hope nobody asks what happens if the badge stops working.
+
+You would not remove the production line because the intern can run around very quickly carrying parts from one station to another.
+
+You would use the intern to learn where the work is broken. You would use it to document the process. You would use it to prototype better ways of operating. You would use it to remove friction from people’s days.
+
+Then, where the work is repeatable and valuable, you would build the machine.
+
+That is the distinction we need to keep clear.
+
+Claude Cowork is not automation.
+
+Agent Skills are not automation.
+
+They are powerful accelerants. They are personal force multipliers. They are a new layer in the way knowledge work gets done. Used well, they will help people feel less buried by repetitive tasks and more capable of producing meaningful work.
+
+But sustainable automation is something else.
+
+Automation is what keeps flowing after the novelty fades. Automation is what survives handover. Automation is what runs without a heroic individual watching every step. Automation is what decouples departmental output from departmental headcount. Automation is what turns a fragile habit into an operating capability.
+
+So yes, build the Agent Skill.
+
+Yes, use Claude Cowork.
+
+Yes, give people the superpower.
+
+But do not confuse the feeling of having the strength of ten people with building a machine that can run without you.


### PR DESCRIPTION
Add a new long-form post that clarifies the distinction between AI-enabled personal productivity (Agent Skills / Claude Cowork) and deterministic operational automation.