### PR TITLE
Fix feed article URLs

### DIFF
--- a/src/pages/feed.json.js
+++ b/src/pages/feed.json.js
@@ -11,10 +11,10 @@ export async function GET() {
     feed_url: 'https://sjg.io/feed.json',
     language: 'en',
     items: posts.map((post) => ({
-      id: post.slug,
+      id: post.id,
       title: post.data.title,
       content_text: post.data.description,
-      url: `https://sjg.io/writing/${post.slug}/`,
+      url: `https://sjg.io/writing/${post.id}/`,
       date_published: post.data.date.toISOString(),
       tags: post.data.tags,
     })),

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -12,7 +12,7 @@ export async function GET(context) {
       title: post.data.title,
       description: post.data.description,
       pubDate: post.data.date,
-      link: `/writing/${post.slug}/`,
+      link: `/writing/${post.id}/`,
     })),
   });
 }


### PR DESCRIPTION
### Motivation
- The JSON feed and RSS items were generating article URLs that resolved to `/writing/undefined/` because they referenced a removed or undefined `slug` property. 
- Syndication feeds should use the canonical content identifier to produce stable article links. 

### Description
- Updated `src/pages/feed.json.js` to use `post.id` for the item `id` and the `url` field instead of `post.slug`.
- Updated `src/pages/rss.xml.js` to use `post.id` for the RSS item `link` instead of `post.slug`.
- This ensures both JSON Feed and RSS use the content entry `id` to construct `/writing/<id>/` URLs.

### Testing
- Ran `npm run lint` which completed without errors.
- `npm run build` and `npm run typecheck` failed on the local Node.js runtime `v20.20.2` due to Astro's Node version requirement, which prevented those scripts from running in the default environment.
- Ran `npx -y node@22.12.0 node_modules/.bin/astro build` which succeeded and produced `dist/feed.json`.
- Ran `npx -y node@22.12.0 node_modules/.bin/astro check` which completed successfully, and a verification script confirmed `dist/feed.json` contains 28 items and 0 URLs containing `undefined`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c00b6568c8329947f6fae2795d4fd)