### PR TITLE
Refresh Now page

### DIFF
--- a/src/content/pages/now.mdx
+++ b/src/content/pages/now.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Now"
 description: "What Simon is focused on right now."
-lastUpdated: "2025-10-03"
+lastUpdated: "2026-05-31"
 ---
 
 import UpdatedBadge from '../../components/UpdatedBadge.astro';
@@ -13,40 +13,55 @@ import Callout from '../../components/Callout.astro';
 
 <Callout variant="neutral" icon="📝">
   <p>
-    This page is inspired by <a href="https://nownownow.com/about" target="_blank" rel="noopener noreferrer">Derek Sivers' now page movement</a>. 
-    It's a snapshot of what I'm currently working on, learning, and thinking about.
+    This page is inspired by <a href="https://nownownow.com/about" target="_blank" rel="noopener noreferrer">Derek Sivers' now page movement</a>.
+    It's a snapshot of what I'm working on, learning, building, and thinking about.
   </p>
 </Callout>
 
 ## 💼 Work
 
-**Operational AI at [Pax8](/work/pax8)**: Building the layer that makes agentic systems safe and measurable in enterprise operations. Focus on patterns, adoption, and outcomes that matter.
+I'm leading Workflow Engineering at [Pax8](/work/pax8), focused on turning AI and automation from impressive demonstrations into dependable operational capability.
 
-**Workflow Engineering**: Leading the transformation of how we build, deploy, and operate software at scale. Creating systems that enable teams to move fast while maintaining reliability.
+The work is about building systems that safely change how work happens: platforms, patterns, governance, measurement, and adoption. I'm especially interested in the space between human judgement, business process, and software engineering.
+
+The questions I keep coming back to are simple:
+
+- Did this reduce work, or just move it?
+- Is the outcome repeatable?
+- Can we measure the improvement?
+- What new failure modes have we introduced?
+- Does this make the organisation more capable?
 
 ## 🚀 Side Projects
 
-**1310 ISP**: Supporting [Matt](https://www.linkedin.com/in/matthewiggo/) as he builds our profitable, self-funded fibre ISP. Steady growth, disciplined engineering, sensible capital allocation.
+I'm still involved with **1310 ISP**, supporting [Matt](https://www.linkedin.com/in/matthewiggo/) as he continues to grow a disciplined, profitable, self-funded infrastructure business.
 
-**sjg.io**: This site - continuously improving, experimenting with new content formats, and maintaining a fast, accessible web presence. Bit of a toy for me right now :)
+I'm also developing the idea of **School in the Woods**: a forest school / alternative provision project for children who need something different from the standard school environment.
+
+This site, **sjg.io**, remains my place to test ideas, write things down, and make sense of what I'm learning.
 
 ## 👨‍👩‍👧‍👦 Family & Life
 
-**Bishopswood School Federation**: Continuing as [school governor](/work/school-governor), focusing on SEN support and the [forest school initiative](/work/forest-school). Chairing collaboration across five schools in the Synergy Schools Partnership.
+I live in Hampshire with my wife and two daughters.
 
-**Property investments**: Building a portfolio to support SEN schooling needs and community initiatives.
+Family life keeps me grounded and heavily shapes what I care about: education, confidence, neurodiversity, practical learning, outdoor time, and building environments where children can feel safe and capable.
+
+I'm also continuing as a [school governor](/work/school-governor), with a particular interest in SEN, collaboration between schools, and schools as communities.
 
 ## 📚 Learning & Exploring
 
-**Measurement frameworks**: Defining metrics that truly indicate AI is doing real work, not just vanity metrics. Focus on toil reduction, service quality, and business outcomes.
+Right now I'm thinking a lot about the difference between:
 
-**AI productivity tooling influx**: Closely monitoring the rapid arrival of AI-enabled productivity tools. Looking for opportunities to pilot, integrate, or build on these at Pax8 where they can drive measurable impact.
+- agents and automation
+- productivity and capability
+- demos and operating models
+- leadership intent and operating rhythm
+- schooling and learning
 
-**Currently reading**: "Agentic Design Patterns" by Antonio Gulli ([read here](https://docs.google.com/document/d/1rsaK53T3Lg5KoGwvf8ukOUvbELRtH-V0LnOIFDxBryE/edit?tab=t.0#heading=h.pxcur8v2qagu)) [Thanks Eric!]
+I'm also still drawn to the things that make systems tangible: networks, aviation, Linux, music, photography, radio, infrastructure, and the craft of understanding how things really work.
 
 ## 🔮 Coming Up Next
 
-- Transform Pax8 with AI-driven operational excellence
-- Launch new forest school
+More focus on Workflow Engineering, operational AI, writing, 1310, School in the Woods, and spending intentional time with family and outdoor projects.
 
 </div>


### PR DESCRIPTION
## Summary

Refreshes the `/now` page with a shorter, more current version focused on:

- Workflow Engineering and operational AI
- 1310
- School in the Woods
- family, education, SEN and practical learning
- current learning themes around agents, automation and capability

## Notes

Updates the page date to 2026-05-31.

Closes #103