### PR TITLE
Soften preview-deploy PR comment

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -70,10 +70,12 @@ jobs:
       with:
         script: |
           const previewUrl = `https://preview${{ github.event.number }}.sjg.io`;
-          const comment = `🚀 **Preview deployed successfully!**
+          const comment = `🚀 **Preview deploying…**
           
           **Preview URL:** ${previewUrl}
-          
+
+          ⏳ Give it a minute or two to become reachable — Cloudflare provisions the custom domain and TLS certificate after the deploy finishes, so a "site can't be reached" error right away just means it's still coming up. Refresh shortly.
+
           This preview will be automatically cleaned up when the PR is merged or closed.`;
           
           github.rest.issues.createComment({


### PR DESCRIPTION
The preview workflow posts its comment the moment `wrangler deploy` returns, but a Cloudflare Workers **custom domain** provisions its DNS record and TLS certificate a short while *after* the deploy finishes. Clicking the link immediately returns a "site can't be reached" error, which reads as "CI never generated the preview" even though it did.

This rewords the comment to set expectations rather than changing any deploy logic:

- Header: **Preview deployed successfully!** → **Preview deploying…**
- Adds a line noting it takes a minute or two to become reachable, and that an immediate "can't be reached" error just means the custom domain is still coming up.

No workflow behaviour changes — comment text only.