### PR TITLE
Add /.well-known/security.txt (RFC 9116)

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:hello@sjg.io
+Expires: 2027-05-31T10:30:38Z
+Canonical: https://sjg.io/.well-known/security.txt
+Preferred-Languages: en


### PR DESCRIPTION
Adds a minimal RFC 9116 `security.txt` served at https://sjg.io/.well-known/security.txt.

Fields:
- `Contact: mailto:hello@sjg.io`
- `Expires: 2027-05-31T10:30:38Z` (~1 year out)
- `Canonical: https://sjg.io/.well-known/security.txt`
- `Preferred-Languages: en`

Note: contact was set to the known-monitored `hello@sjg.io`. The owner may switch to a dedicated `security@` alias if/when it is monitored.

Closes #104