### PR TITLE
Make AI crawler policy explicit in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,22 @@
+# This is a public personal/writing site. Crawlers are welcome — including AI
+# crawlers. The policy below is intentionally permissive and explicit.
+
+# Search engines and all other crawlers
 User-agent: *
+Allow: /
+
+# AI crawlers — explicitly allowed (training, search, and on-demand fetching)
+User-agent: GPTBot
+User-agent: ChatGPT-User
+User-agent: OAI-SearchBot
+User-agent: ClaudeBot
+User-agent: PerplexityBot
+User-agent: Google-Extended
+User-agent: CCBot
+User-agent: Applebot-Extended
+User-agent: Bytespider
+User-agent: Amazonbot
+User-agent: Meta-ExternalAgent
 Allow: /
 
 Sitemap: https://sjg.io/sitemap-index.xml


### PR DESCRIPTION
Makes the AI crawler policy in `public/robots.txt` explicit while keeping the site fully discoverable.

## Changes
- Keep `User-agent: *` / `Allow: /` so normal search indexing is unaffected.
- Add named AI crawlers grouped together with an explicit `Allow: /`: GPTBot, ChatGPT-User, OAI-SearchBot, ClaudeBot, PerplexityBot, Google-Extended, CCBot, Applebot-Extended, Bytespider, Amazonbot, Meta-ExternalAgent.
- Retain the `Sitemap: https://sjg.io/sitemap-index.xml` declaration.
- Add brief comments documenting the intentional, permissive stance.

This signals a deliberate, permissive policy aligned with the site's public publishing goals.

Closes #98