### PR TITLE
Bug: homepage Now summary falls back after Now page refresh

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -26,6 +26,7 @@ const pages = defineCollection({
     title: z.string(),
     description: z.string().optional(),
     updated: z.date().optional(),
+    homepageSummary: z.string().optional(),
   }),
 });
 

--- a/src/content/pages/now.mdx
+++ b/src/content/pages/now.mdx
@@ -2,6 +2,7 @@
 title: "Now"
 description: "What Simon is focused on right now."
 lastUpdated: "2026-05-31"
+homepageSummary: "I'm focused on turning AI and automation from impressive demonstrations into dependable operational capability.\n\nThat means building systems that safely change how work happens: platforms, patterns, governance, measurement, and adoption. I'm especially interested in the space between human judgement, business process, and software engineering."
 ---
 
 import UpdatedBadge from '../../components/UpdatedBadge.astro';

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,25 +6,11 @@ import LogoRow from '../components/LogoRow.astro';
 import { getCollection } from 'astro:content';
 import { marked } from 'marked';
 
-// Get the "now" page content for the focus section
+// Get the "now" page homepage summary for the focus section
 const nowPage = await getCollection('pages', ({ id }) => id === 'now');
 const nowContent = nowPage[0];
-
-// Extract a short summary from the now page content
-let nowSummary = "Figuring out what's next...";
-if (nowContent) {
-  // Get the first paragraph from the "Current work" section
-  const content = nowContent.body ?? '';
-  const currentWorkMatch = content.match(/## Current work\s*\n\n(.*?)(?=\n##|\n\*\*|$)/s);
-  if (currentWorkMatch) {
-    const currentWorkText = currentWorkMatch[1];
-    // Extract the first sentence or two, but keep markdown formatting
-    const sentences = currentWorkText.split(/[.!?]+/).filter(s => s.trim().length > 0);
-    const markdownText = sentences.slice(0, 2).join('. ').trim() + '.';
-    // Convert markdown to HTML
-    nowSummary = await marked(markdownText);
-  }
-}
+const nowSummaryMarkdown = nowContent?.data.homepageSummary ?? "Figuring out what's next...";
+const nowSummary = await marked(nowSummaryMarkdown);
 
 // Get recent posts for the writing section
 const allPosts = await getCollection('posts', ({ data }) => !data.draft);


### PR DESCRIPTION
## Summary

The homepage "What I'm focused on now" section currently extracts copy from the `/now` page using a regex that looks for a `## Current work` heading.

The refreshed Now page uses a `## 💼 Work` heading instead, so the homepage can fall back to the default text:

```text
Figuring out what's next...
```

## Proposed fix

Make the homepage summary explicit rather than regex-derived by adding a `homepageSummary` field to the `/now` page frontmatter and rendering that on the homepage when present.

Recommended homepage copy:

```text
I'm focused on turning AI and automation from impressive demonstrations into dependable operational capability.

That means building systems that safely change how work happens: platforms, patterns, governance, measurement, and adoption. I'm especially interested in the space between human judgement, business process, and software engineering.
```

## Acceptance criteria

- The homepage no longer depends on parsing a specific heading in `now.mdx`.
- The homepage renders the proposed summary under "What I'm focused on now".
- The `/now` page can continue using its current section headings without breaking the homepage.
- The fallback text remains available only as a true fallback.