### PR TITLE
Preview config: mirror production integrations (fixes 404 sitemap on previews)

### DIFF
--- a/astro.config.preview.mjs
+++ b/astro.config.preview.mjs
@@ -1,21 +1,14 @@
+// Preview build config. Identical to the production config (astro.config.mjs)
+// except for `site`, which is the per-PR preview domain. Extending the base
+// config rather than duplicating it keeps the two from drifting — previously
+// this file omitted the `sitemap()` and `react()` integrations, so previews
+// 404'd on /sitemap-0.xml and would not hydrate React islands.
 import { defineConfig } from 'astro/config';
-import mdx from '@astrojs/mdx';
-import tailwindcss from '@tailwindcss/vite';
+import baseConfig from './astro.config.mjs';
 
 const previewDomain = process.env.PREVIEW_DOMAIN || 'preview.sjg.io';
 
 export default defineConfig({
+  ...baseConfig,
   site: `https://${previewDomain}`,
-  base: '/',
-  output: 'static',
-  integrations: [mdx()],
-  markdown: {
-    shikiConfig: {
-      theme: 'github-dark',
-      wrap: true
-    }
-  },
-  vite: {
-    plugins: [tailwindcss()],
-  },
 });


### PR DESCRIPTION
On preview deploys, `https://preview<N>.sjg.io/sitemap-0.xml` 404s and the colophon's Sitemap link is dead (spotted on preview114). Production is fine.

**Cause:** `astro.config.preview.mjs` had drifted from `astro.config.mjs`. It declared only `integrations: [mdx()]` with a bare `markdown` block, so it was missing the `sitemap()` integration and the shared remark/rehype plugins (`remark-gfm`, `rehype-footnote-class`). Preview builds never emitted the sitemap files, and preview markdown rendered without GFM/footnote handling.

**Fix:** derive the preview config from the production config (`...baseConfig`) and override only `site` with the per-PR preview domain. The two configs can no longer drift.

Verified locally: `PREVIEW_DOMAIN=preview114.sjg.io astro build --config astro.config.preview.mjs` now emits `dist/sitemap-0.xml` + `dist/sitemap-index.xml` with `https://preview114.sjg.io/...` locs.