### PR TITLE
Add RSS and JSON feed discovery links to <head>

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -39,6 +39,8 @@ const canonicalUrl = canonical || new URL(Astro.url.pathname, Astro.site);
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="canonical" href={canonicalUrl} />
     {markdownPath && <link rel="alternate" type="text/markdown" href={markdownPath} />}
+    <link rel="alternate" type="application/rss+xml" title="sjg.io — RSS feed" href="/rss.xml" />
+    <link rel="alternate" type="application/feed+json" title="sjg.io — JSON feed" href="/feed.json" />
     
     <!-- Typography: Inter is self-hosted via @fontsource-variable/inter (imported in this layout), so no external font requests are made. -->
 


### PR DESCRIPTION
Adds `<link rel="alternate">` tags announcing the existing RSS (`/rss.xml`) and JSON (`/feed.json`) feeds in `src/layouts/Base.astro`, so feed readers can auto-discover them on every page.

Per the [Feed Discovery spec](https://specification.website/spec/foundations/feed-discovery/): correct format-specific MIME types (`application/rss+xml`, `application/feed+json`), descriptive titles, and `href`.

Before: `curl -s https://sjg.io/ | grep rel=.alternate` returned nothing.

Closes #125