### PR TITLE
[spec] Add color-scheme meta tag

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -59,8 +59,10 @@ const canonicalUrl = canonical || new URL(Astro.url.pathname, Astro.site);
         
         if (theme === 'dark') {
           document.documentElement.classList.add('dark');
+          document.documentElement.style.colorScheme = 'dark';
         } else {
           document.documentElement.classList.remove('dark');
+          document.documentElement.style.colorScheme = 'light';
         }
       })();
       
@@ -76,9 +78,11 @@ const canonicalUrl = canonical || new URL(Astro.url.pathname, Astro.site);
             
             if (html.classList.contains('dark')) {
               html.classList.remove('dark');
+              html.style.colorScheme = 'light';
               localStorage.setItem('theme', 'light');
             } else {
               html.classList.add('dark');
+              html.style.colorScheme = 'dark';
               localStorage.setItem('theme', 'dark');
             }
           }
@@ -119,6 +123,14 @@ const canonicalUrl = canonical || new URL(Astro.url.pathname, Astro.site);
 <style is:global>
   html {
     font-family: system-ui, sans-serif;
+    /* Tie native surfaces (scrollbars, form controls, canvas) to the active
+       theme rather than the OS preference. The inline theme script also sets
+       this before paint; this keeps it correct as a CSS-level fallback. */
+    color-scheme: light;
+  }
+
+  html.dark {
+    color-scheme: dark;
   }
   
   /* Fix table headers in dark mode */

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -36,6 +36,7 @@ const canonicalUrl = canonical || new URL(Astro.url.pathname, Astro.site);
     <meta charset="UTF-8" />
     <meta name="description" content={description} />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="canonical" href={canonicalUrl} />
     {markdownPath && <link rel="alternate" type="text/markdown" href={markdownPath} />}


### PR DESCRIPTION
Adds `<meta name="color-scheme" content="light dark">` to the document head in `src/layouts/Base.astro`.

sjg.io supports both light and dark themes via the class-based toggle, but did not declare this to the browser. The meta tag lets the browser render native UI (form controls, scrollbars) and the initial canvas background to match the active scheme, and avoids the white flash dark-mode users can see before CSS loads.

`light` is listed first so light remains the default fallback; the existing theme toggle continues to control actual page colors via the `dark` class.

Closes #119
