### PR TITLE
rss: feed content hygiene (atom self-link, lastBuildDate, syndication)

### DIFF
--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -8,7 +8,11 @@ export async function GET(context) {
   const lastBuildDate =
     posts.length > 0
       ? new Date(
-          Math.max(...posts.map((post) => post.data.date.getTime())),
+          Math.max(
+            ...posts.map((post) =>
+              (post.data.updated ?? post.data.date).getTime(),
+            ),
+          ),
         ).toUTCString()
       : new Date().toUTCString();
 

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -3,11 +3,30 @@ import { getCollection } from 'astro:content';
 
 export async function GET(context) {
   const posts = await getCollection('posts', ({ data }) => !data.draft);
-  
+
+  const feedUrl = new URL('rss.xml', context.site).href;
+  const lastBuildDate =
+    posts.length > 0
+      ? new Date(
+          Math.max(...posts.map((post) => post.data.date.getTime())),
+        ).toUTCString()
+      : new Date().toUTCString();
+
   return rss({
     title: 'sjg.io',
     description: "Simon's personal website and blog",
     site: context.site,
+    xmlns: {
+      atom: 'http://www.w3.org/2005/Atom',
+      sy: 'http://purl.org/rss/1.0/modules/syndication/',
+    },
+    customData: [
+      `<atom:link href="${feedUrl}" rel="self" type="application/rss+xml"/>`,
+      `<lastBuildDate>${lastBuildDate}</lastBuildDate>`,
+      `<language>en-GB</language>`,
+      `<sy:updatePeriod>weekly</sy:updatePeriod>`,
+      `<sy:updateFrequency>1</sy:updateFrequency>`,
+    ].join(''),
     items: posts.map((post) => ({
       title: post.data.title,
       description: post.data.description,


### PR DESCRIPTION
Closes #124

Brings `/rss.xml` up to the [Feed content hygiene](https://specification.website/spec/foundations/feed-hygiene/) spec (Foundations #13).

## Changes
`src/pages/rss.xml.js` now passes `@astrojs/rss` two extra options:

- `xmlns` declaring `xmlns:atom` and `xmlns:sy` on the `<rss>` element.
- `customData` injecting channel-level metadata:
  - `<atom:link href="https://sjg.io/rss.xml" rel="self" .../>` — the self-reference both feed validators warn about when missing.
  - `<lastBuildDate>` — derived from the most recent post date so aggregators can skip unchanged feeds.
  - `<language>en-GB</language>`.
  - `<sy:updatePeriod>weekly</sy:updatePeriod>` + `<sy:updateFrequency>1</sy:updateFrequency>` — Syndication module polling cadence.

Stable GUIDs, RFC 822 `pubDate`, and absolute item links were already correct and are unchanged. Archive pagination (RFC 5005) is not applicable — single-page feed.

## Verification
Rendered the feed with `getRssString` using the same options; output is well-formed and includes the namespaces plus all new channel elements in the correct position (before `<item>`s). The repo-wide `npm run build` could not run in the isolated worktree due to an unrelated font-package resolution issue against the symlinked node_modules; the feed endpoint logic itself is verified.