### PR TITLE
Add IndexNow key file

### DIFF
--- a/public/084d3e0f1f9f87ae98fe0edd7ebd7688.txt
+++ b/public/084d3e0f1f9f87ae98fe0edd7ebd7688.txt
@@ -1,0 +1,1 @@
+084d3e0f1f9f87ae98fe0edd7ebd7688


### PR DESCRIPTION
Adds the IndexNow verification key file required by the [IndexNow spec item](https://specification.website/spec/seo/indexnow/).

## Change
- New static file `public/084d3e0f1f9f87ae98fe0edd7ebd7688.txt` containing the 32-char key. Cloudflare serves `public/` assets directly, so it resolves at `https://sjg.io/084d3e0f1f9f87ae98fe0edd7ebd7688.txt` as `text/plain` with a `200` (no redirects), satisfying spec requirements 1 and 2.

## Scope
This PR only hosts the key file (the trivial, safe prerequisite). The URL-submission-on-publish step (POST to the IndexNow API on deploy, including deletions) is intentionally left as a follow-up because it requires a workflow/design decision — see the issue.

Part of #132