### PR TITLE
Fix homepage heading hierarchy (h1 -> h3 skip)

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -69,7 +69,7 @@ const logos = [
       <div class="grid grid-cols-1 gap-8 md:grid-cols-3">
         <Card href="/work/pax8">
           <div class="p-6">
-            <h3 class="text-xl font-black text-gray-900 dark:text-white">Pax8, global product pods</h3>
+            <h2 class="text-xl font-black text-gray-900 dark:text-white">Pax8, global product pods</h2>
             <p class="mt-3 text-base text-gray-600 dark:text-gray-300">
               Rebuilt internal IT from a single region service to a worldwide, pod based, product oriented organisation. Focus on adoption, measurable outcomes, and speed.
             </p>
@@ -77,7 +77,7 @@ const logos = [
         </Card>
         <Card href="/work/1310">
           <div class="p-6">
-            <h3 class="text-xl font-black text-gray-900 dark:text-white">1310, profitable and self funded</h3>
+            <h2 class="text-xl font-black text-gray-900 dark:text-white">1310, profitable and self funded</h2>
             <p class="mt-3 text-base text-gray-600 dark:text-gray-300">
               Built an ISP organically to self sustaining profitability. Engineering discipline, sensible capital, steady execution.
             </p>
@@ -85,7 +85,7 @@ const logos = [
         </Card>
         <Card href="/writing/operational-ai-that-actually-ships">
           <div class="p-6">
-            <h3 class="text-xl font-black text-gray-900 dark:text-white">Automation and AI that ships</h3>
+            <h2 class="text-xl font-black text-gray-900 dark:text-white">Automation and AI that ships</h2>
             <p class="mt-3 text-base text-gray-600 dark:text-gray-300">
               Operational AI and automation that reduces toil and improves service quality. Focus on routing, adoption, and measurable outcomes.
             </p>


### PR DESCRIPTION
The homepage outline skipped a heading level: the hero `<h1>` was followed directly by the three "Three Proof Points" cards rendered as `<h3>`, with no intervening `<h2>` (first `<h2>` was "What I'm focused on now").

Verified live before the change:
```
h1  Simon Green
h3  Pax8, global product pods        <- skips h2
h3  1310, profitable and self funded
h3  Automation and AI that ships
h2  What I'm focused on now
h2  Writing
```

Skipped heading levels are a direct WCAG 2.4.6 (AA) failure.

These three proof points are top-level page sections, peers of the later "What I'm focused on now" and "Writing" `<h2>` headings, so this promotes them from `<h3>` to `<h2>`. Visual styling is unchanged because the size classes are set explicitly on each heading.

Note: this PR addresses only the homepage skip. The issue also documents a duplicate `<h1>` on `/contact` and a "Menu" `<h2>` that precedes the document `<h1>` in source order; those need separate judgment and are left for follow-up.

Closes #137