### PR TITLE
Add global visible focus indicators

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -77,6 +77,25 @@
     font-weight: 600;
     letter-spacing: -0.02em;
   }
+
+  /*
+   * Visible focus indicators (WCAG 2.4.7 / 2.4.11 / 2.4.13).
+   * Consistent, high-contrast (3:1+) ring for keyboard users only,
+   * 2px thick and offset so it never disappears into borders.
+   * :focus-visible avoids showing the ring on mouse/touch interaction.
+   */
+  :focus-visible {
+    outline: 2px solid var(--color-neon-blue);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  /* Keep focused controls clear of the sticky header when scrolled into view. */
+  :target,
+  a[id],
+  [tabindex] {
+    scroll-margin-top: 5rem;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
Closes #143

Adds a single global `:focus-visible` rule in `src/styles/globals.css` so every focusable element shows a consistent, intentional focus indicator for keyboard users:

- 2px solid neon-blue outline with 2px offset (>3:1 contrast, satisfies WCAG 2.4.7 / 2.4.11; meets 2.4.13 thickness).
- `:focus-visible` means the ring only appears for keyboard navigation, not mouse clicks.
- `scroll-margin-top` keeps focused targets clear of the sticky header.

This upgrades plain links (header nav, footer, prose) from the inconsistent browser-default outline to an intentional site-wide indicator, and provides a uniform baseline alongside the existing per-component Tailwind rings.

Pure CSS addition inside the existing `@layer base` block; braces verified balanced. (A full `npm run build` in the worktree fails only due to a pre-existing, unrelated `@fontsource-variable/inter` resolution quirk in the symlinked node_modules, not this change.)
