### PR TITLE
a11y: descriptive link text for homepage Now button

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -107,7 +107,7 @@ const logos = [
         </div>
         <div class="mt-6">
           <Button href="/now" variant="outline">
-            Read more
+            Read what I'm focused on now
           </Button>
         </div>
       </div>


### PR DESCRIPTION
Replaces the generic "Read more" button on the homepage "What I'm focused on now" section with descriptive text: "Read what I'm focused on now".

Generic link text fails the destination-clarity guidance in WCAG 2.4.4 / 2.4.9; screen-reader users navigating by links list now get a clear destination. One-line copy change in `src/pages/index.astro`.

Closes #142
