### PR TITLE
a11y: skip-to-content link and main landmark id

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -105,9 +105,15 @@ const canonicalUrl = canonical || new URL(Astro.url.pathname, Astro.site);
     
   </head>
       <body class="h-full bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+    <a
+      href="#main"
+      class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-gray-900 focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-neon-blue dark:focus:bg-gray-800 dark:focus:text-gray-100"
+    >
+      Skip to content
+    </a>
     <div class="min-h-full">
       <Header />
-      <main>
+      <main id="main">
         <slot />
       </main>
       <Footer />


### PR DESCRIPTION
## Summary
Improves landmark/skip-navigation accessibility per spec item 34 (Semantic HTML and landmarks).

- Adds `id="main"` to the single `<main>` landmark in `src/layouts/Base.astro` so it can serve as a skip-link target.
- Adds a visually-hidden "Skip to content" link as the first focusable element in `<body>`, which becomes visible on keyboard focus (Tailwind `sr-only` + `focus:not-sr-only`) and jumps to `#main`.

The site already had a strong semantic baseline (`<header>`, `<nav aria-label="Top">`, `<main>`, `<footer>`, `<article>`, one `<h1>` per page); these two additions close the remaining gaps the spec calls out.

## Notes
Pure markup change using built-in Tailwind v4 utilities; no JS, no design decisions. (The local build in this environment cannot resolve `@fontsource-variable/inter` without a full install — this is pre-existing and unrelated to this diff.)

Closes #140
