### PR TITLE
Fix footer colour contrast to meet WCAG AA

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -8,7 +8,7 @@ const currentYear = new Date().getFullYear();
       <div class="flex items-center space-x-6">
         <a 
           href="https://github.com/simonjgreen" 
-          class="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
+          class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
           aria-label="Simon Green on GitHub"
         >
           <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
@@ -17,7 +17,7 @@ const currentYear = new Date().getFullYear();
         </a>
         <a
           href="https://twitter.com/SimonJGreen"
-          class="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
+          class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
           aria-label="Simon Green on Twitter"
         >
           <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
@@ -26,7 +26,7 @@ const currentYear = new Date().getFullYear();
         </a>
         <a
           href="https://bsky.app/profile/sjg.io"
-          class="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
+          class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
           aria-label="Simon Green on Bluesky"
         >
           <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
@@ -35,7 +35,7 @@ const currentYear = new Date().getFullYear();
         </a>
         <a
           href="https://linkedin.com/in/simonjgreen"
-          class="text-gray-400 hover:text-gray-500 dark:hover:text-gray-300"
+          class="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
           aria-label="Simon Green on LinkedIn"
         >
           <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
@@ -46,10 +46,10 @@ const currentYear = new Date().getFullYear();
       <div class="text-center md:text-right text-sm text-gray-500 dark:text-gray-400 space-y-2">
         <div>
           © {currentYear} Simon Green. All rights reserved.
-          <a href="/colophon" class="ml-1 md:ml-4 text-gray-400 hover:text-gray-500 dark:hover:text-gray-300">Colophon</a>
-          <a href="/privacy" class="ml-1 md:ml-4 text-gray-400 hover:text-gray-500 dark:hover:text-gray-300">Privacy</a>
+          <a href="/colophon" class="ml-1 md:ml-4 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">Colophon</a>
+          <a href="/privacy" class="ml-1 md:ml-4 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200">Privacy</a>
         </div>
-        <p class="text-xs text-gray-400 dark:text-gray-500">
+        <p class="text-xs text-gray-500 dark:text-gray-400">
           The views on this website are my own and do not represent the views of my employers.
         </p>
       </div>


### PR DESCRIPTION
Closes #147.

Fixes WCAG 2.2 AA colour-contrast failures in the site footer (src/components/Footer.astro).

In light mode the footer renders on bg-white. The social icon links, the Colophon/Privacy links, and the legal disclaimer all used text-gray-400 = 2.54:1, below the 3:1 (non-text/icon) and 4.5:1 (small text) thresholds. The dark-mode disclaimer (dark:text-gray-500) was 3.67:1.

Changes (token-only, no layout impact):
- Resting colour for icons and links: text-gray-500 dark:text-gray-400 (4.83:1 light, 6.99:1 dark)
- Hover: text-gray-700 dark:text-gray-200
- Disclaimer: text-gray-500 dark:text-gray-400

All footer text/icons now meet WCAG AA.
