### PR TITLE
Honour prefers-reduced-motion site-wide

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -52,6 +52,22 @@
     font-feature-settings: 'tnum' 1, 'kern' 1;
   }
 
+  /*
+   * Honour the user's reduced-motion preference.
+   * Neutralises animations, transitions and smooth scrolling for people who
+   * experience motion sickness, vestibular disorders, migraines or seizures.
+   */
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
+
   body {
     @apply bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100;
   }


### PR DESCRIPTION
Adds a global `@media (prefers-reduced-motion: reduce)` block to `src/styles/globals.css` that reduces animation and transition durations to ~0 and forces `scroll-behavior: auto`.

The colophon already advertises "prefers-reduced-motion support" but no such rule existed in the codebase or the served CSS. The site defines infinite `float`/`glow` keyframe animations and uses `transition` utilities across many components; this change ensures all of that is neutralised for users who opt in via their OS, with zero effect on everyone else.

Implements the recommended CSS approach from the [Reduced motion](https://specification.website/spec/accessibility/reduced-motion/) spec item.

Closes #150