### PR TITLE
[spec] Internal linking: crawlable post links on writing index and tag pages

### DIFF
--- a/src/pages/writing/index.astro
+++ b/src/pages/writing/index.astro
@@ -31,7 +31,9 @@ const formatDate = (date: Date) => {
       {posts.map((post) => (
         <Card class="cursor-pointer post-card" data-href={`/writing/${post.id}`}>
           <h2 class="text-xl font-semibold text-gray-900 dark:text-white hover:text-neon-blue dark:hover:text-neon-blue transition-colors">
-            {post.data.title}
+            <a href={`/writing/${post.id}`} class="hover:text-neon-blue dark:hover:text-neon-blue">
+              {post.data.title}
+            </a>
           </h2>
           <p class="mt-2 text-gray-600 dark:text-gray-300">
             {post.data.description}

--- a/src/pages/writing/tags/[tag].astro
+++ b/src/pages/writing/tags/[tag].astro
@@ -65,7 +65,9 @@ const formatDate = (date: Date) => {
       {postsWithTag.map((post) => (
         <Card class="cursor-pointer post-card" data-href={`/writing/${post.id}`}>
           <h2 class="text-xl font-semibold text-gray-900 dark:text-white hover:text-neon-blue dark:hover:text-neon-blue transition-colors">
-            {post.data.title}
+            <a href={`/writing/${post.id}`} class="hover:text-neon-blue dark:hover:text-neon-blue">
+              {post.data.title}
+            </a>
           </h2>
           <p class="mt-2 text-gray-600 dark:text-gray-300">
             {post.data.description}


### PR DESCRIPTION
Closes #149

## Problem

The writing index (`/writing/`) and tag pages (`/writing/tags/<tag>`) navigated to individual posts only via a JavaScript click handler — each post card was a `<div class="post-card" data-href="/writing/…">` with `window.location.href` on click, with no `<a href>` to the post. Crawlers and AI agents that do not execute JS could not follow these links, leaving older posts reachable only through the XML sitemap and feeds. This is the "JavaScript-only navigation without `<a href>` fallbacks" anti-pattern from the [internal linking spec](https://specification.website/spec/seo/internal-linking/).

## Change

Wrap each post title in a real `<a href="/writing/<slug>">` on both pages. The existing full-card JS click remains as progressive enhancement — its handler already bails out when the click target is inside an anchor (`e.target.closest('a')`), so there is no double-navigation, and the tag pills (siblings of the title anchor, not nested) stay valid.

## Verification

`npx astro check` passes with 0 errors (pre-existing `event`-deprecation hints unchanged). Full `npm run build` could not run in this worktree due to an unrelated missing `@fontsource-variable/inter` in the shared node_modules symlink, not related to this change.
