### PR TITLE
Make Markdown data tables accessible

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 import remarkGfm from 'remark-gfm';
 import rehypeFootnoteClass from './src/plugins/rehype-footnote-class.mjs';
+import rehypeAccessibleTables from './src/plugins/rehype-accessible-tables.mjs';
 import { readdirSync, readFileSync } from 'node:fs';
 
 // The Markdown export endpoint (src/pages/writing/[...slug].md.ts) emits a
@@ -30,11 +31,11 @@ export default defineConfig({
   output: 'static',
   integrations: [mdx({
     remarkPlugins: [remarkGfm],
-    rehypePlugins: [rehypeFootnoteClass]
+    rehypePlugins: [rehypeFootnoteClass, rehypeAccessibleTables]
   }), sitemap({ customPages: markdownWritingUrls() })],
   markdown: {
     remarkPlugins: [remarkGfm],
-    rehypePlugins: [rehypeFootnoteClass],
+    rehypePlugins: [rehypeFootnoteClass, rehypeAccessibleTables],
     shikiConfig: {
       theme: 'github-dark',
       wrap: true

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/simon/Documents/sjg-io/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/simon/Documents/sjg-io/node_modules

--- a/src/plugins/rehype-accessible-tables.mjs
+++ b/src/plugins/rehype-accessible-tables.mjs
@@ -1,0 +1,46 @@
+import { visit } from 'unist-util-visit';
+
+/**
+ * Make GFM-generated data tables accessible:
+ *  - add `scope="col"` to header cells in <thead> (GFM tables are column-header tables)
+ *  - wrap each <table> in a focusable, labelled scroll region so keyboard users
+ *    can reach and scroll wide tables on narrow viewports (WCAG 1.3.1 / 2.1.1)
+ *
+ * @type {import('rehype').Plugin<[], import('hast').Root>}
+ */
+export default function rehypeAccessibleTables() {
+  return (tree) => {
+    // 1. Add scope="col" to <th> cells inside <thead>.
+    visit(tree, 'element', (node) => {
+      if (node.tagName !== 'thead') return;
+      visit(node, 'element', (cell) => {
+        if (cell.tagName === 'th') {
+          cell.properties = cell.properties || {};
+          if (!cell.properties.scope) {
+            cell.properties.scope = 'col';
+          }
+        }
+      });
+    });
+
+    // 2. Wrap each <table> in a focusable region for horizontal scrolling.
+    visit(tree, 'element', (node, index, parent) => {
+      if (node.tagName !== 'table' || !parent || typeof index !== 'number') return;
+      // Skip if already wrapped.
+      if (parent.tagName === 'div' && parent.properties?.role === 'region') return;
+
+      const wrapper = {
+        type: 'element',
+        tagName: 'div',
+        properties: {
+          className: ['table-region'],
+          role: 'region',
+          'aria-label': 'Table, scroll horizontally to view all columns',
+          tabIndex: 0
+        },
+        children: [node]
+      };
+      parent.children[index] = wrapper;
+    });
+  };
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -113,6 +113,13 @@
     outline-offset: 2px;
   }
 
+  /* The wrapper owns the overflow, so the table itself must not scroll. */
+  .prose .table-region > table {
+    display: table;
+    max-width: none;
+    overflow-x: visible;
+  }
+
   /* Background textures - keeping only the working particle effect */
   .bg-texture-particles {
     background-image:

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -100,6 +100,19 @@
     white-space: normal;
   }
 
+  /* Focusable scroll region wrapping wide data tables (a11y) */
+  .prose .table-region {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .prose .table-region:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+  }
+
   /* Background textures - keeping only the working particle effect */
   .bg-texture-particles {
     background-image:


### PR DESCRIPTION
Closes #156

## What

Adds `src/plugins/rehype-accessible-tables.mjs` (wired into both the MDX and Markdown rehype pipelines in `astro.config.mjs`) that post-processes GFM-generated tables to:

1. Add `scope="col"` to `<th>` header cells inside `<thead>` — so screen readers announce the column context of each data cell (WCAG 1.3.1).
2. Wrap each `<table>` in a focusable `<div role="region" tabindex="0" aria-label="…">` scroll container — so keyboard users can reach and horizontally scroll wide tables on narrow viewports (WCAG 2.1.1).

`src/styles/globals.css` gains a `.table-region` rule (scroll container + a `:focus-visible` outline). The existing `.prose table` overflow rules are left in place as a harmless fallback.

## Why

The writing posts contain real data tables (e.g. `/writing/the-2026-computer-literate-bar/`) whose live HTML had no `scope` attributes and no focusable scroll region. This is the only meaningful accessible-tables gap that can be fixed generically; per-table `<caption>` and `id`/`headers` for complex headers remain an authoring concern.

## Verification

Built the markdown pipeline directly through unified; output for a sample table:

```html
<div class="table-region" role="region" aria-label="Table, scroll horizontally to view all columns" tabindex="0"><table>
<thead><tr><th scope="col">A</th><th scope="col">B</th></tr></thead>
<tbody><tr><td>1</td><td>2</td></tr></tbody>
</table></div>
```

The plugin only adds attributes/wrappers and does not alter table content.