### PR TITLE
Add Content-Signal directive to robots.txt

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/simon/Documents/sjg-io/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/simon/Documents/sjg-io/node_modules

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,6 +4,9 @@
 # Search engines and all other crawlers
 User-agent: *
 Allow: /
+# Content Signals (experimental, specification.website): indexing, live AI
+# fetching, and AI training are all permitted, matching the policy above.
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
 # AI crawlers — explicitly allowed (training, search, and on-demand fetching)
 User-agent: GPTBot

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -21,5 +21,9 @@ User-agent: Bytespider
 User-agent: Amazonbot
 User-agent: Meta-ExternalAgent
 Allow: /
+# Content Signals (repeated here because robots.txt matching uses the single
+# most-specific User-agent group; these AI crawlers would otherwise not see
+# the signals declared in the wildcard group above).
+Content-Signal: search=yes, ai-input=yes, ai-train=yes
 
 Sitemap: https://sjg.io/sitemap-index.xml


### PR DESCRIPTION
Adds the experimental `Content-Signal:` directive ([specification.website](https://specification.website/spec/agent-readiness/content-signals/), Agent Readiness #74) to the `User-agent: *` group in `public/robots.txt`.

```
Content-Signal: search=yes, ai-input=yes, ai-train=yes
```

This formalises the site's already-stated permissive AI-crawler policy (search indexing, live AI fetching, and AI training all allowed) in machine-readable form. The directive is ignored by crawlers that do not yet parse it, so it carries no risk. Static file under `public/` — no build verification needed.

Closes #161