### PR TITLE
[spec] HTTP Link headers for discovery

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,3 +5,4 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()
   Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; connect-src 'self' https://cloudflareinsights.com; upgrade-insecure-requests
+  Link: </llms.txt>; rel="describedby"; type="text/plain", </sitemap-index.xml>; rel="sitemap"; type="application/xml", </rss.xml>; rel="alternate"; type="application/rss+xml", </feed.json>; rel="alternate"; type="application/feed+json", </.well-known/security.txt>; rel="security"


### PR DESCRIPTION
Adds an HTTP \`Link\` header to the global \`/*\` rule in \`public/_headers\`, advertising the site's machine-readable resources at the edge layer:

- \`/llms.txt\` (rel=describedby)
- \`/sitemap-index.xml\` (rel=sitemap)
- \`/rss.xml\` (rel=alternate)
- \`/feed.json\` (rel=alternate)
- \`/.well-known/security.txt\` (rel=security)

This enables HTML-free discovery for agents and crawlers, works on non-HTML endpoints, and aligns with the agent-readiness specification's recommendation to configure Link headers at the CDN/edge layer. All referenced resources already exist and return 200.

Closes #162