### PR TITLE
Cache fingerprinted /_astro assets immutably

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,3 +5,8 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()
   Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; connect-src 'self' https://cloudflareinsights.com; upgrade-insecure-requests
+
+# Fingerprinted assets carry a content hash in their filename, so they can be
+# cached immutably for a year (RFC 9111). A new build produces a new filename.
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
Closes #170

Adds a `/_astro/*` rule to `public/_headers` setting `Cache-Control: public, max-age=31536000, immutable`.

These build outputs (hashed CSS, JS, woff2 fonts) carry a content hash in their filename, so they are safe to cache for a year per RFC 9111 — a new build produces a new filename, busting the cache automatically. Previously they inherited the page-level `max-age=0, must-revalidate` policy, forcing an unnecessary revalidation round-trip on every visit.

HTML continues to use `max-age=0, must-revalidate` + ETag (already spec-compliant). Pure static-file change under `public/`; no build affected.