### PR TITLE
Add RSS and JSON feed autodiscovery links to head

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -39,6 +39,8 @@ const canonicalUrl = canonical || new URL(Astro.url.pathname, Astro.site);
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="canonical" href={canonicalUrl} />
     {markdownPath && <link rel="alternate" type="text/markdown" href={markdownPath} />}
+    <link rel="alternate" type="application/rss+xml" title="sjg.io" href="/rss.xml" />
+    <link rel="alternate" type="application/feed+json" title="sjg.io" href="/feed.json" />
     
     <!-- Typography: Inter is self-hosted via @fontsource-variable/inter (imported in this layout), so no external font requests are made. -->
 


### PR DESCRIPTION
Closes #167

The site serves an RSS 2.0 feed (`/rss.xml`) and a JSON Feed 1.1 (`/feed.json`), but neither was linked from any page's `<head>`, so feed readers and agents landing on the site could not autodiscover them.

This adds two site-wide `<link rel="alternate">` tags in `src/layouts/Base.astro`, following the same pattern as the existing markdown alternate link:

```html
<link rel="alternate" type="application/rss+xml" title="sjg.io" href="/rss.xml" />
<link rel="alternate" type="application/feed+json" title="sjg.io" href="/feed.json" />
```

Completes spec item 78 (Agent Readiness — Machine-readable formats).