### PR TITLE
[spec] No-Vary-Search response header

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -5,3 +5,4 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()
   Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com; connect-src 'self' https://cloudflareinsights.com; upgrade-insecure-requests
+  No-Vary-Search: key-order, params=("utm_source" "utm_medium" "utm_campaign" "utm_term" "utm_content" "gclid" "fbclid" "ref" "mc_cid" "mc_eid")


### PR DESCRIPTION
Adds a `No-Vary-Search` response header to `public/_headers` so the browser HTTP cache and Speculation Rules prefetch/prerender cache treat common tracking parameters (and query-param order) as non-varying.

The site is fully static with no functional query-param handling, so links carrying `utm_*`, `gclid`, `fbclid`, etc. currently fragment the cache and prefetch unnecessarily. The header collapses those variants onto a single cached copy.

```
No-Vary-Search: key-order, params=("utm_source" "utm_medium" "utm_campaign" "utm_term" "utm_content" "gclid" "fbclid" "ref" "mc_cid" "mc_eid")
```

Static-file-only change under `public/`; no build impact.

Closes #172