### PR TITLE
Prioritise post header image for LCP (Core Web Vitals)

### DIFF
--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -53,9 +53,13 @@ const formatDate = (date: Date) => {
       <header class="mb-8">
         {image && (
           <div class="mb-8">
-            <img 
-              src={image} 
+            <img
+              src={image}
               alt={title}
+              width="896"
+              height="256"
+              fetchpriority="high"
+              decoding="async"
               class="w-full h-64 object-cover rounded-lg shadow-lg"
             />
           </div>


### PR DESCRIPTION
Closes #177

The post header image is the likely Largest Contentful Paint element on posts that have one, but it rendered as a plain `<img>` with only CSS classes — no fetch priority, no intrinsic dimensions, no decoding hint.

This adds to `src/layouts/Post.astro`:

- `fetchpriority="high"` so the browser fetches the LCP image at high priority instead of default, improving LCP.
- `width="896"` / `height="256"` matching the rendered box (`max-w-4xl` container = 896px, `h-64` = 256px) to give the correct intrinsic aspect ratio and reserve layout space (CLS).
- `decoding="async"`.

CSS classes are unchanged, so responsive behaviour and appearance are identical. No design or content decisions involved.

Note: a full `npm run build` could not be run in the worktree because `@fontsource-variable/inter` is not present in the shared node_modules (pre-existing environment gap, unrelated to this change); the edit only adds standard HTML attributes to an existing element.