### PR TITLE
Add schema.org JSON-LD structured data

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -12,6 +12,7 @@ export interface Props {
   ogImage?: string;
   canonical?: string;
   markdownPath?: string;
+  jsonLd?: Record<string, unknown> | Record<string, unknown>[];
 }
 
 const {
@@ -21,13 +22,16 @@ const {
   ogDescription,
   ogImage,
   canonical,
-  markdownPath
+  markdownPath,
+  jsonLd
 } = Astro.props;
 
 const siteTitle = title === "sjg.io" ? title : `${title} | Simon Green`;
 const ogTitleFinal = ogTitle || title;
 const ogDescriptionFinal = ogDescription || description;
 const canonicalUrl = canonical || new URL(Astro.url.pathname, Astro.site);
+
+const jsonLdBlocks = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
 ---
 
 <!DOCTYPE html>
@@ -102,7 +106,12 @@ const canonicalUrl = canonical || new URL(Astro.url.pathname, Astro.site);
     {ogImage && <meta name="twitter:image" content={new URL(ogImage, Astro.site)} />}
     
     <title>{siteTitle}</title>
-    
+
+    <!-- Structured data (schema.org JSON-LD) for search engines and agents -->
+    {jsonLdBlocks.map((block) => (
+      <script type="application/ld+json" set:html={JSON.stringify(block)} />
+    ))}
+
   </head>
       <body class="h-full bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
     <div class="min-h-full">

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -32,6 +32,17 @@ const ogDescriptionFinal = ogDescription || description;
 const canonicalUrl = canonical || new URL(Astro.url.pathname, Astro.site);
 
 const jsonLdBlocks = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
+
+// Serialize JSON-LD for safe injection into a <script> tag. JSON.stringify does
+// not escape '<', '>' or '&', so a value containing '</script>' could otherwise
+// prematurely close the tag (invalid HTML / injection vector). Escape those
+// characters as their \u-unicode equivalents; the JSON remains valid and parses
+// back to the original string.
+const serializeJsonLd = (block: Record<string, unknown>): string =>
+  JSON.stringify(block)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
 ---
 
 <!DOCTYPE html>
@@ -109,7 +120,7 @@ const jsonLdBlocks = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
 
     <!-- Structured data (schema.org JSON-LD) for search engines and agents -->
     {jsonLdBlocks.map((block) => (
-      <script type="application/ld+json" set:html={JSON.stringify(block)} />
+      <script type="application/ld+json" set:html={serializeJsonLd(block)} />
     ))}
 
   </head>

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -37,16 +37,45 @@ const formatDate = (date: Date) => {
     day: 'numeric'
   }).format(date);
 };
+
+const postUrl = canonical || new URL(Astro.url.pathname, Astro.site).toString();
+
+const blogPostingJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'BlogPosting',
+  '@id': postUrl,
+  headline: title,
+  ...(description && { description }),
+  url: postUrl,
+  mainEntityOfPage: postUrl,
+  datePublished: date.toISOString(),
+  dateModified: (updated ?? date).toISOString(),
+  ...(image && { image: new URL(image, Astro.site).toString() }),
+  ...(tags.length > 0 && { keywords: tags }),
+  inLanguage: 'en-GB',
+  author: {
+    '@type': 'Person',
+    '@id': new URL('/about', Astro.site).toString() + '#person',
+    name: 'Simon Green',
+    url: Astro.site?.toString()
+  },
+  publisher: {
+    '@type': 'Person',
+    '@id': new URL('/about', Astro.site).toString() + '#person',
+    name: 'Simon Green'
+  }
+};
 ---
 
-<Base 
-  title={title} 
+<Base
+  title={title}
   description={description}
   ogTitle={ogTitle}
   ogDescription={ogDescription}
   ogImage={image}
   canonical={canonical}
   markdownPath={markdownPath}
+  jsonLd={blogPostingJsonLd}
 >
   <article class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 py-12">
     <div class="max-w-3xl">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,9 +35,34 @@ const logos = [
   { name: 'NFL', url: '#', logo: '/logos/nfl.svg', invertInLight: true },
 ];
 
+const siteUrl = Astro.site?.toString() ?? 'https://sjg.io/';
+const personId = new URL('/about', Astro.site).toString() + '#person';
+
+const homeJsonLd = [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    '@id': siteUrl + '#website',
+    url: siteUrl,
+    name: 'sjg.io',
+    description: 'Simon Green: Builder CIO. I bring AI out of the lab and into operations.',
+    inLanguage: 'en-GB',
+    publisher: { '@id': personId }
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    '@id': personId,
+    name: 'Simon Green',
+    url: siteUrl,
+    jobTitle: 'Builder CIO',
+    description: 'Simon Green: Builder CIO. I bring AI out of the lab and into operations.'
+  }
+];
+
 ---
 
-<Base title="Home" description="Simon Green: Builder CIO. I bring AI out of the lab and into operations.">
+<Base title="Home" description="Simon Green: Builder CIO. I bring AI out of the lab and into operations." jsonLd={homeJsonLd}>
   <!-- Hero Section -->
       <section class="bg-gray-50 dark:bg-gray-900 bg-texture-particles relative overflow-hidden">
     <div class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 py-24 relative z-10">


### PR DESCRIPTION
Closes #178

Adds schema.org JSON-LD structured data so search engines and agents can parse page content from the static HTML (present before any JS runs).

## Changes
- **`src/layouts/Base.astro`**: new optional `jsonLd` prop (object or array) rendered as one or more `<script type="application/ld+json">` blocks in `<head>`.
- **`src/layouts/Post.astro`**: emits a `BlogPosting` (headline, description, url, datePublished, dateModified, image, keywords from tags, `inLanguage: en-GB`, author/publisher Person).
- **`src/pages/index.astro`**: emits `WebSite` + `Person`.

The Person entity uses a stable `@id` of `https://sjg.io/about#person`, reused on both posts and the home page per the spec's `@id` reuse guidance. All fields mirror visible page content (no invented or inflated values).

## Verification
JSON-LD output was validated for correct shape/structure (valid schema.org BlogPosting/WebSite/Person). Note: a full `npm run build` could not run in the isolated worktree because `@fontsource-variable/inter` is absent from the shared node_modules (a pre-existing environment limitation unrelated to this change — line 4 of Base.astro is untouched). The additions are standard Astro prop plumbing plus a `set:html` script block; the new prop is optional so existing `<Base>` consumers are unaffected. Recommend confirming via the PR preview deploy and Google's Rich Results Test.