### PR TITLE
Add native lazy loading and decoding hints to images

### DIFF
--- a/src/components/ArticleLink.astro
+++ b/src/components/ArticleLink.astro
@@ -33,9 +33,11 @@ const formatDate = (date: Date) => {
   <Card href={`/writing/${post.id}`} class="mt-8">
     <div class="p-6">
       {post.data.image && (
-        <img 
-          src={post.data.image} 
+        <img
+          src={post.data.image}
           alt={post.data.title}
+          loading="lazy"
+          decoding="async"
           class="w-full h-32 object-cover rounded-lg mb-4"
         />
       )}

--- a/src/components/LogoRow.astro
+++ b/src/components/LogoRow.astro
@@ -22,9 +22,11 @@ const { logos, title = "Trusted by" } = Astro.props;
     <div class="flex flex-wrap items-center justify-center gap-8 opacity-60">
       {logos.map((logo) => (
         <div class="flex items-center logo-container">
-          <img 
-            src={logo.logo} 
+          <img
+            src={logo.logo}
             alt={logo.name}
+            loading="lazy"
+            decoding="async"
             class={`h-8 w-auto logo-img transition-all duration-200 ${logo.logo.endsWith('.svg') ? 'logo-svg' : 'logo-png'} ${
               logo.invertInLight ? 'logo-invert-light' : ''
             }`}

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -53,9 +53,12 @@ const formatDate = (date: Date) => {
       <header class="mb-8">
         {image && (
           <div class="mb-8">
-            <img 
-              src={image} 
+            <img
+              src={image}
               alt={title}
+              loading="eager"
+              fetchpriority="high"
+              decoding="async"
               class="w-full h-64 object-cover rounded-lg shadow-lg"
             />
           </div>


### PR DESCRIPTION
Addresses the Performance / [Lazy loading](https://specification.website/spec/performance/lazy-loading/) spec item for the shared image components (the low-risk, self-contained part).

## Changes
- **`Post.astro`** header image: `loading="eager"` + `fetchpriority="high"` + `decoding="async"`. This is the LCP element, so it is explicitly *not* lazy-loaded and is prioritised, per the spec's guidance to protect LCP content.
- **`ArticleLink.astro`** card thumbnails: `loading="lazy"` + `decoding="async"` (off-screen below cards/fold).
- **`LogoRow.astro`** logos: `loading="lazy"` + `decoding="async"` (off-screen row of ~10+ images on the homepage).

Pure attribute additions to existing `<img>` tags; no layout or behaviour change.

## Not in this PR (tracked in the issue)
In-content MDX `<img>` tags and the `<video>` in the Intel prank post (which would benefit from `preload="metadata"`) are content-level edits left as follow-up; a future move to Astro's `<Image />` would handle these automatically.

Closes #175