### PR TITLE
[spec] Scrollbar gutter

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -50,6 +50,10 @@
   html {
     font-family: system-ui, sans-serif;
     font-feature-settings: 'tnum' 1, 'kern' 1;
+    /* Reserve scrollbar space to prevent horizontal layout shift when
+       content overflow toggles (e.g. navigation between short/long pages).
+       No visual effect with overlay scrollbars. */
+    scrollbar-gutter: stable;
   }
 
   body {


### PR DESCRIPTION
Adds `scrollbar-gutter: stable` to the `html` rule in `src/styles/globals.css`.

This reserves space for the classic scrollbar so the viewport width stays constant when a page toggles between having and not having a vertical scrollbar (e.g. navigating from a short page to a long one). It removes the ~15px horizontal jolt and reduces Cumulative Layout Shift. On platforms with overlay scrollbars (macOS default, mobile) it has no visual effect, so it is a safe, zero-cost enhancement.

Single CSS declaration, no design or content changes.

Closes #191
