### PR TITLE
Add last-updated date to privacy policy

### DIFF
--- a/src/content/pages/privacy.mdx
+++ b/src/content/pages/privacy.mdx
@@ -3,6 +3,8 @@ title: "Privacy"
 description: "What this site does and doesn't do with your data - in plain English."
 ---
 
+_Last updated: 31 May 2026._
+
 This is a personal website. It collects as little as possible about you, and what it does collect can't identify you. Here's the whole story, no legal jargon.
 
 ## Analytics


### PR DESCRIPTION
Adds a visible "Last updated" date to the top of the privacy policy.

A visible last-updated date is a mandatory transparency element for a privacy policy ([spec](https://specification.website/spec/privacy/privacy-policy/), requirement #9). The existing policy at `/privacy` already covers analytics, cookies, fonts, email, and no-selling in plain English; this adds the missing date.

Content-only change to `src/content/pages/privacy.mdx` (one italic markdown line). Broader GDPR-completeness items (lawful basis, data subject rights, retention, transfer safeguards) are content/legal decisions left for the site owner and tracked separately.

Closes #192