### PR TITLE
Add custom 404 page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,22 @@
+---
+import Page from '../layouts/Page.astro';
+---
+
+<Page
+  title="Page not found"
+  description="That page could not be found. Here are some places to go instead."
+>
+  <p>
+    The page you were looking for does not exist or may have moved. The link
+    you followed might be broken, or the page may have been removed.
+  </p>
+  <p>Here are some places to go instead:</p>
+  <ul>
+    <li><a href="/">Home</a></li>
+    <li><a href="/writing">Writing</a></li>
+    <li><a href="/work">Work</a></li>
+    <li><a href="/about">About</a></li>
+    <li><a href="/now">Now</a></li>
+    <li><a href="/contact">Contact</a></li>
+  </ul>
+</Page>

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,13 +3,15 @@
   "name": "sjg-io",
   "compatibility_date": "2025-01-08",
   "assets": {
-    "directory": "./dist"
+    "directory": "./dist",
+    "not_found_handling": "404-page"
   },
   "env": {
     "production": {
       "name": "sjg-io",
       "assets": {
-        "directory": "./dist"
+        "directory": "./dist",
+        "not_found_handling": "404-page"
       },
       "routes": [
         {


### PR DESCRIPTION
Closes #198.

Adds a branded custom 404 page so unmatched routes show on-brand content instead of Cloudflare's empty default body.

## What changed

- New `src/pages/404.astro` built on the existing `Page` layout (same pattern as `contact.astro`), so it inherits site styling, header/footer, dark mode, and meta tags with no extra JS.
- Clear "Page not found" heading plus links to Home, Writing, Work, About, Now, and Contact.

## How it works

Astro emits `404.html` for `src/pages/404.astro`. Cloudflare static-asset hosting serves that file for unmatched routes, preserving the existing `HTTP 404` status (verified live: `curl -sI https://sjg.io/<missing>` already returns `404` with an empty body today).

## Scope note

No 500 page is included: the site is a static Astro build on Cloudflare static assets with no server runtime, so application 500s do not occur; any 5xx would come from the Cloudflare edge and is not configurable from this repo.
