### PR TITLE
Add cross-document View Transitions

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,7 +6,7 @@ const currentPath = Astro.url.pathname;
 const isHomePage = currentPath === '/';
 ---
 
-    <header class="bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
+    <header id="site-header" class="bg-gray-50 dark:bg-gray-900 border-b border-gray-200 dark:border-gray-700">
   <nav class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8" aria-label="Top">
     {isHomePage ? (
       <div class="flex w-full items-center justify-center py-6">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -45,6 +45,35 @@
   }
 }
 
+/*
+ * Cross-document View Transitions.
+ * Animates full-page (MPA) navigations with the browser-default short
+ * cross-fade. Progressive enhancement: browsers without support simply do an
+ * instant navigation, so there is no regression. The site header is given a
+ * stable view-transition-name (#site-header, below) so it stays in place while
+ * the page content cross-fades.
+ */
+@view-transition {
+  navigation: auto;
+}
+
+/*
+ * Honour reduced-motion for transitions too: disable the view-transition
+ * animations entirely for users who opt out of motion.
+ */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
+}
+
+/* Keep the site header visually stable across navigations. */
+#site-header {
+  view-transition-name: site-header;
+}
+
 /* Base styles */
 @layer base {
   html {


### PR DESCRIPTION
Implements #188 (optional performance/UX enhancement).

## What this does
- Adds `@view-transition { navigation: auto; }` to `src/styles/globals.css` so MPA (full-page) navigations animate with the browser-default short cross-fade.
- Gives the site header a stable `view-transition-name` (via a new `id="site-header"`) so it stays in place while page content cross-fades — a more app-like feel. An `id` is used (not the `header` element) to avoid a duplicate `view-transition-name` with the article `<header>` in `Post.astro`.
- Disables the view-transition animations under `prefers-reduced-motion: reduce`.

## Notes
- **Progressive enhancement:** Chromium animates; browsers without cross-document view-transition support simply navigate instantly — no regression, no JS added.
- **No CSP impact:** pure CSS, no inline scripts.
- Best viewed in a Chromium browser. Navigate between pages (e.g. Home → Writing → an article) to see the cross-fade with the header holding steady.

Closes #188