### PR TITLE
structured data: add Person sameAs + @graph consolidation

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -38,27 +38,36 @@ const logos = [
 const siteUrl = Astro.site?.toString() ?? 'https://sjg.io/';
 const personId = new URL('/about', Astro.site).toString() + '#person';
 
-const homeJsonLd = [
-  {
-    '@context': 'https://schema.org',
-    '@type': 'WebSite',
-    '@id': siteUrl + '#website',
-    url: siteUrl,
-    name: 'sjg.io',
-    description: 'Simon Green: Builder CIO. I bring AI out of the lab and into operations.',
-    inLanguage: 'en-GB',
-    publisher: { '@id': personId }
-  },
-  {
-    '@context': 'https://schema.org',
-    '@type': 'Person',
-    '@id': personId,
-    name: 'Simon Green',
-    url: siteUrl,
-    jobTitle: 'Builder CIO',
-    description: 'Simon Green: Builder CIO. I bring AI out of the lab and into operations.'
-  }
-];
+// Single @graph per page with cross-referenced @id nodes (schema.org best
+// practice). sameAs lists Simon's verified profiles, sourced from the footer.
+const homeJsonLd = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebSite',
+      '@id': siteUrl + '#website',
+      url: siteUrl,
+      name: 'sjg.io',
+      description: 'Simon Green: Builder CIO. I bring AI out of the lab and into operations.',
+      inLanguage: 'en-GB',
+      publisher: { '@id': personId }
+    },
+    {
+      '@type': 'Person',
+      '@id': personId,
+      name: 'Simon Green',
+      url: siteUrl,
+      jobTitle: 'Builder CIO',
+      description: 'Simon Green: Builder CIO. I bring AI out of the lab and into operations.',
+      sameAs: [
+        'https://github.com/simonjgreen',
+        'https://linkedin.com/in/simonjgreen',
+        'https://twitter.com/SimonJGreen',
+        'https://bsky.app/profile/sjg.io'
+      ]
+    }
+  ]
+};
 
 ---
 


### PR DESCRIPTION
Completes the remaining items from #131.

Most of #131 (emit `WebSite` + `Person` + `BlogPosting` JSON-LD with absolute URLs and ISO 8601 dates) was already delivered by the merged **#184**. This finishes the two outstanding pieces:

1. **`sameAs`** on the `Person` node — Simon's verified profiles, sourced from the site footer:
   - `https://github.com/simonjgreen`
   - `https://linkedin.com/in/simonjgreen`
   - `https://twitter.com/SimonJGreen`
   - `https://bsky.app/profile/sjg.io`
2. **Single `@graph` per page** — the homepage `WebSite` + `Person` are now one `@graph` block with `@id` cross-references (schema.org best practice), instead of two separate top-level objects.

### Verification
`lint` ✓ · `typecheck` ✓ (0 errors) · `build` ✓ · `validate:feeds` ✓ (JSON-LD valid, 19 blocks scanned). Rendered homepage graph confirmed in the built output.

Closes #131