### PR TITLE
markdown endpoints: Vary: Accept + charset for /writing/*.md

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -12,3 +12,10 @@
 # cached immutably for a year (RFC 9111). A new build produces a new filename.
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable
+
+# Per-page Markdown source endpoints (/writing/<slug>.md). Re-assert the
+# charset that Cloudflare strips from static assets, and Vary: Accept so the
+# Markdown representation is cached distinctly from its HTML counterpart.
+/writing/*.md
+  Content-Type: text/markdown; charset=utf-8
+  Vary: Accept


### PR DESCRIPTION
Closes the achievable recommended gaps from #164 for the per-page Markdown source endpoints.

Adds a `public/_headers` rule for `/writing/*.md`:
- `Content-Type: text/markdown; charset=utf-8` — re-asserts the charset that Cloudflare strips from static-asset responses
- `Vary: Accept` — so the Markdown representation is cached distinctly from its HTML counterpart

### Scope
The mandatory `.md`-suffix endpoints already shipped in #114; this finishes the recommended header hygiene. The remaining spec items — `Accept:`-based content negotiation on the HTML URL, and `.md` for static (non-writing) pages — require a server runtime / a content refactor and add little value for a static personal site, so they're intentionally out of scope (see the closing note on #164).

### Verify on the preview
`curl -sI https://preview<N>.sjg.io/writing/email-is-not-dead.md` should now show `vary: accept` and `content-type: text/markdown; charset=utf-8`.

Refs #164