### PR TITLE
Support article Open Graph type for posts

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -10,8 +10,11 @@ export interface Props {
   ogTitle?: string;
   ogDescription?: string;
   ogImage?: string;
+  ogType?: 'website' | 'article';
   canonical?: string;
   markdownPath?: string;
+  articlePublishedTime?: string;
+  articleModifiedTime?: string;
   jsonLd?: Record<string, unknown> | Record<string, unknown>[];
 }
 
@@ -21,8 +24,11 @@ const {
   ogTitle,
   ogDescription,
   ogImage,
+  ogType = 'website',
   canonical,
   markdownPath,
+  articlePublishedTime,
+  articleModifiedTime,
   jsonLd
 } = Astro.props;
 
@@ -155,11 +161,17 @@ const serializeJsonLd = (block: Record<string, unknown>): string =>
     </script>
     
     <!-- Open Graph -->
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content={ogType} />
     <meta property="og:title" content={ogTitleFinal} />
     <meta property="og:description" content={ogDescriptionFinal} />
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:site_name" content="sjg.io" />
+    {ogType === 'article' && articlePublishedTime && (
+      <meta property="article:published_time" content={articlePublishedTime} />
+    )}
+    {ogType === 'article' && articleModifiedTime && (
+      <meta property="article:modified_time" content={articleModifiedTime} />
+    )}
     {ogImage && <meta property="og:image" content={new URL(ogImage, Astro.site)} />}
     {ogImage && <meta property="og:image:width" content="1200" />}
     {ogImage && <meta property="og:image:height" content="630" />}

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -75,8 +75,11 @@ const blogPostingJsonLd = {
   ogTitle={ogTitle}
   ogDescription={ogDescription}
   ogImage={image?.src}
+  ogType="article"
   canonical={canonical}
   markdownPath={markdownPath}
+  articlePublishedTime={date.toISOString()}
+  articleModifiedTime={(updated ?? date).toISOString()}
   jsonLd={blogPostingJsonLd}
 >
   <article class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 py-12">


### PR DESCRIPTION
### Motivation
- Ensure posts emit the correct Open Graph type and associated article timestamps so social platforms and crawlers receive accurate metadata.
- Make the Open Graph output configurable at the layout level so non-post pages remain `og:type=website` while posts can be `og:type=article` with timestamps.
- Partial work on #123: this change addresses the `og:type` portion only and intentionally does not add a default OG image, so it does not auto-close the issue.

### Description
- Add a typed `ogType?: 'website' | 'article'` prop (default `website`) and `articlePublishedTime` / `articleModifiedTime` props to `Base.astro` and expose them via `Astro.props`.
- Use `ogType` in `Base.astro` to render `<meta property="og:type" content={ogType} />` and conditionally render `article:published_time` and `article:modified_time` when `ogType === 'article'` and timestamps are provided.
- Update `Post.astro` to pass `ogType="article"` and supply `articlePublishedTime={date.toISOString()}` and `articleModifiedTime={(updated ?? date).toISOString()}` while preserving existing JSON-LD output.
- Keep existing behavior for non-article pages by defaulting `ogType` to `website` so the homepage and other pages are unaffected.

### Testing
- Ran `npm run typecheck` (succeeded after switching to a supported Node version via `mise` to satisfy Astro's `>=22.12.0` requirement).
- Ran `npm run build` (succeeded and produced static output under `dist/`).
- Ran `npm run lint` (ESLint completed successfully).
- Automated verification: inspected built HTML files and confirmed a post page contains `property="og:type" content="article"` and `article:published_time` / `article:modified_time`, while the homepage contains `property="og:type" content="website"`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ca82ba8048329bef5533820ea16fb)