### PR TITLE
Remap non-canonical tags on Gen 5 AI harness post

### DIFF
--- a/src/content/posts/gen-5-ai-enterprise-harness-war.mdx
+++ b/src/content/posts/gen-5-ai-enterprise-harness-war.mdx
@@ -2,7 +2,7 @@
 title: "Gen 5 AI and the Enterprise Harness War"
 description: "Why the next enterprise AI fight is less about the smartest model and more about the harness: interfaces, runtimes, connectors, skills, governance, identity and agent-ready software."
 date: 2026-06-16
-tags: ["ai", "agents", "enterprise", "saas", "identity"]
+tags: ["ai", "agents", "enterprise", "platforms", "security"]
 ---
 
 I think we are entering Gen 5 of the assistive AI era.


### PR DESCRIPTION
## Summary
- \`gen-5-ai-enterprise-harness-war.mdx\` used tags \`saas\` and \`identity\`, which aren't in the canonical tags list — this broke \`validate:tags\` on main and blocked CI on every other open PR
- Remapped to existing canonical tags: \`saas\` → \`platforms\`, \`identity\` → \`security\`

## Test plan
- [x] \`npm run validate:tags\` passes locally