### PR TITLE
Add two new articles and an opt-in table of contents

### DIFF
--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,168 @@
+---
+import type { MarkdownHeading } from 'astro';
+
+export interface Props {
+  headings: MarkdownHeading[];
+  /** 'sidebar' floats beside the article on large screens; 'inline' collapses above it on small ones. */
+  variant?: 'sidebar' | 'inline';
+  /** Deepest heading level to list. The layout owns the h1, so depth 2 is the top level here. */
+  maxDepth?: number;
+}
+
+const { headings, variant = 'sidebar', maxDepth = 2 } = Astro.props;
+
+const items = headings.filter(
+  (heading) => heading.depth >= 2 && heading.depth <= maxDepth && heading.slug
+);
+---
+
+{
+  items.length > 1 && (
+    <>
+      {variant === 'sidebar' ? (
+        <nav class="toc hidden lg:block" aria-labelledby="toc-heading">
+          <h2
+            id="toc-heading"
+            class="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400"
+          >
+            On this page
+          </h2>
+          <ul class="mt-4 space-y-1 border-l border-gray-200 dark:border-gray-700">
+            {items.map((heading) => (
+              <li>
+                <a
+                  href={`#${heading.slug}`}
+                  data-toc-link={heading.slug}
+                  class="-ml-px block border-l border-transparent py-1 pl-4 text-sm leading-snug text-gray-500 transition-colors hover:border-gray-400 hover:text-gray-900 dark:text-gray-400 dark:hover:border-gray-500 dark:hover:text-white"
+                >
+                  {heading.text}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      ) : (
+        <details class="toc mb-10 rounded-lg border border-gray-200 bg-white/50 dark:border-gray-700 dark:bg-gray-800/50 lg:hidden">
+          <summary class="cursor-pointer list-none px-4 py-3 text-sm font-semibold text-gray-900 dark:text-white [&::-webkit-details-marker]:hidden">
+            <span class="inline-flex w-full items-center justify-between gap-2">
+              <span>On this page</span>
+              <span class="text-xs font-normal text-gray-500 dark:text-gray-400">
+                {items.length} sections
+              </span>
+            </span>
+          </summary>
+          <ul class="space-y-1 border-t border-gray-200 px-4 py-3 dark:border-gray-700">
+            {items.map((heading) => (
+              <li>
+                <a
+                  href={`#${heading.slug}`}
+                  data-toc-link={heading.slug}
+                  class="block py-1 text-sm leading-snug text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                >
+                  {heading.text}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </>
+  )
+}
+
+<style>
+  /*
+   * Active section, set by the scroll-spy below. Scoped to the sidebar so the
+   * collapsed mobile list stays a plain set of links.
+   */
+  nav.toc a[aria-current='true'] {
+    border-color: var(--color-neon-blue);
+    color: var(--color-gray-900);
+    font-weight: 500;
+  }
+
+  :global(html.dark) nav.toc a[aria-current='true'] {
+    color: #fff;
+  }
+</style>
+
+<script>
+  /*
+   * Scroll-spy: marks the section currently under the top of the viewport.
+   * Runs once per page even when the component is rendered twice (sidebar +
+   * inline), since Astro hoists and dedupes this module.
+   */
+  function initTableOfContents() {
+    const links = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>('a[data-toc-link]')
+    );
+    if (links.length === 0) return;
+
+    // A slug can appear twice (sidebar and inline lists), so group by target.
+    const linksBySlug = new Map<string, HTMLAnchorElement[]>();
+    for (const link of links) {
+      const slug = link.dataset.tocLink;
+      if (!slug) continue;
+      linksBySlug.set(slug, [...(linksBySlug.get(slug) ?? []), link]);
+    }
+
+    const targets = Array.from(linksBySlug.keys())
+      .map((slug) => document.getElementById(slug))
+      .filter((el): el is HTMLElement => el !== null);
+    if (targets.length === 0) return;
+
+    let current: string | null = null;
+
+    const setActive = (slug: string | null) => {
+      if (slug === current) return;
+      if (current) {
+        for (const link of linksBySlug.get(current) ?? []) {
+          link.removeAttribute('aria-current');
+        }
+      }
+      if (slug) {
+        for (const link of linksBySlug.get(slug) ?? []) {
+          link.setAttribute('aria-current', 'true');
+        }
+      }
+      current = slug;
+    };
+
+    const update = () => {
+      // The last heading that has passed the reading line is the active one.
+      const readingLine = 96;
+      let active: HTMLElement | null = null;
+      for (const target of targets) {
+        if (target.getBoundingClientRect().top <= readingLine) {
+          active = target;
+        } else {
+          break;
+        }
+      }
+
+      // Past the end of the document, keep the final section lit rather than
+      // letting a short last section never activate.
+      const atBottom =
+        window.innerHeight + window.scrollY >= document.body.scrollHeight - 2;
+      if (atBottom) active = targets[targets.length - 1];
+
+      setActive(active?.id ?? null);
+    };
+
+    let ticking = false;
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        update();
+        ticking = false;
+      });
+    };
+
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll, { passive: true });
+    update();
+  }
+
+  initTableOfContents();
+</script>

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -33,7 +33,12 @@ const items = headings.filter(
                 <a
                   href={`#${heading.slug}`}
                   data-toc-link={heading.slug}
-                  class="-ml-px block border-l border-transparent py-1 pl-4 text-sm leading-snug text-gray-500 transition-colors hover:border-gray-400 hover:text-gray-900 dark:text-gray-400 dark:hover:border-gray-500 dark:hover:text-white"
+                  class:list={[
+                    '-ml-px block border-l border-transparent py-1 text-sm leading-snug transition-colors hover:border-gray-400 dark:hover:border-gray-500',
+                    heading.depth === 2
+                      ? 'pl-4 font-medium text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white'
+                      : 'pl-7 text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
+                  ]}
                 >
                   {heading.text}
                 </a>
@@ -57,7 +62,12 @@ const items = headings.filter(
                 <a
                   href={`#${heading.slug}`}
                   data-toc-link={heading.slug}
-                  class="block py-1 text-sm leading-snug text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                  class:list={[
+                    'block py-1 text-sm leading-snug hover:text-gray-900 dark:hover:text-white',
+                    heading.depth === 2
+                      ? 'font-medium text-gray-800 dark:text-gray-200'
+                      : 'pl-4 text-gray-600 dark:text-gray-400'
+                  ]}
                 >
                   {heading.text}
                 </a>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -14,6 +14,8 @@ const posts = defineCollection({
       updated: z.date().optional(),
       tags: z.array(z.string()).default([]),
       draft: z.boolean().default(false),
+      // Opt in to the sidebar table of contents, generated from the post's headings.
+      toc: z.boolean().default(false),
       hero: z.string().optional(),
       image: image().optional(),
       canonical: z.string().optional(),

--- a/src/content/posts/the-rules-i-try-to-do-business-by.mdx
+++ b/src/content/posts/the-rules-i-try-to-do-business-by.mdx
@@ -229,7 +229,7 @@ Do not bring them in at the end to apply a coat of UX paint.
 
 ### Think in systems
 
-Most business problems are not isolated events. They are products of a system.
+Most business problems are products of a system rather than isolated events.
 
 A missed target may be an individual performance problem. It may also be the predictable result of incentives, workload, unclear ownership, poor information, or a process that rewards the wrong behaviour.
 
@@ -369,7 +369,7 @@ Software cannot operate on folklore.
 
 Automation can therefore be a forcing function for better process and systems design.
 
-The objective is not to reproduce every existing step in software. It is to question the steps.
+The objective is to question the steps, not reproduce every existing one in software. You must think in terms of systems and be critical of what you are studying.
 
 Do we need this approval? Why are we asking for information we already have? Why does the work pass through three queues? Why does a person have to decide which team receives it?
 
@@ -527,7 +527,7 @@ That does not put them beyond criticism. Bad sales behaviour can create enormous
 
 **The respect has to work both ways.** Sales must respect the people who fulfil the promises, and delivery must respect the people who create the opportunity to make those promises.
 
-Acquiring, serving, and retaining a customer are not separate activities. They are parts of the same system.
+Acquiring, serving, and retaining a customer are all part of the same flywheel, and if you drop one the system falls apart.
 
 ### Use a meeting structure that works
 

--- a/src/content/posts/the-rules-i-try-to-do-business-by.mdx
+++ b/src/content/posts/the-rules-i-try-to-do-business-by.mdx
@@ -5,7 +5,6 @@ date: 2026-08-01
 tags: ["leadership", "culture", "operations", "systems-thinking", "organisation-design", "automation", "work-life-balance"]
 toc: true
 ---
-
 import Callout from '../../components/Callout.astro';
 
 <Callout variant="neutral" icon="😤">
@@ -28,7 +27,9 @@ I think they are customers, and customers can fire you. Internally, they just do
 
 What follows is not a grand theory of management or a neat framework I sat down and invented. It is a collection of rules, habits, and bits of borrowed wisdom that have shaped how I try to build services, lead teams, and do business with people.
 
-## Make it easy to do business with you
+## Start with the customer
+
+### Make it easy to do business with you
 
 Any friction is bad.
 
@@ -54,7 +55,7 @@ Those distinctions may matter greatly to you. They probably do not matter at all
 
 Customers should be able to describe the outcome they need. It is your job to work out what happens next.
 
-## Be the customer
+### Be the customer
 
 Use your own tools, systems, and processes.
 
@@ -76,9 +77,7 @@ Every one of those privileges makes it easier for them to get something done and
 
 The shoulder tap is particularly dangerous. You encounter a problem, message somebody you know, and it is resolved immediately. From your perspective, the organisation appears responsive and effective.
 
-The ordinary customer does not know who to message. They submit a request, receive a generic acknowledgement, and wait. They may be passed between teams, asked for information the organisation already holds, or directed towards instructions that do not quite work.
-
-You and the customer may nominally be using the same service, but you are not having the same experience.
+The ordinary customer does not know who to message. They submit a request, receive a generic acknowledgement, and wait. They may be passed between teams, asked for information the organisation already holds, or directed towards instructions that do not quite work. You and the customer may nominally be using the same service, but you are not having the same experience.
 
 The more senior you become, the more deliberately you need to remove that insulation. Use a normal account. Start with the public documentation. Resist the urge to intervene at the first sign of friction.
 
@@ -88,15 +87,13 @@ Leaders should mystery shop their own organisations. Product teams should use th
 
 You cannot improve an experience you have arranged never to receive.
 
-## You get exactly one chance to make a first impression
+### You get exactly one chance to make a first impression
 
 Yeah yeah, I know, it's a cliché, but that's because it's true!
 
 The first interaction establishes the customer's mental model of everything that follows. It tells them whether you are attentive, competent, organised, and interested.
 
-A poor first impression creates a trust deficit that you may spend months correcting. A good one creates confidence and buys a certain amount of patience for the day when something inevitably goes wrong.
-
-This applies to the first sales conversation, the onboarding experience, the first screen of an application, and the first time an employee contacts an internal support team.
+A poor first impression creates a trust deficit that you may spend months correcting. A good one creates confidence and buys a certain amount of patience for the day when something inevitably goes wrong. This applies to the first sales conversation, the onboarding experience, the first screen of an application, and the first time an employee contacts an internal support team.
 
 Customers do not experience your strategy deck. They experience moments.
 
@@ -120,9 +117,7 @@ It would be tempting to dismiss this as an isolated thing. However, as is often 
 
 The due diligence went on to uncover a business riddled with problems that came from the same underlying behaviour. Processes had been neglected. Details had been ignored. Problems that everybody could see had become normal because nobody felt responsible for dealing with them.
 
-The Yellow Pages did not cause the problems, obviously. But they were a giant warning light drawing immediate attention to them. And not only that, every single visitor to the office was presented with that warning light in their first impression.
-
-They also revealed where the expectation bar had been set for everybody working in that company.
+The Yellow Pages did not cause the problems, obviously. But they were a giant warning light drawing immediate attention to them. And not only that, every single visitor to the office was presented with that warning light in their first impression. They also revealed where the expectation bar had been set for everybody working in that company.
 
 Every person who walked past those directories received the same quiet message: this is acceptable here. Things can be left. Details do not matter. If everybody else has ignored it, you may ignore it too.
 
@@ -148,9 +143,7 @@ Then ask what they are telling people. What is your team learning about the stan
 
 Where is your bar? Not the one written into your values or your strategy deck. The one your team can see from where they are sitting.
 
-Customers cannot see most of what happens inside a service provider. They cannot inspect your architecture, internal controls, project plan, or the quality of the discussions taking place behind the scenes.
-
-They make judgements from the evidence available to them, and that evidence often consists of tiny details.
+Customers cannot see most of what happens inside a service provider. They cannot inspect your architecture, internal controls, project plan, or the quality of the discussions taking place behind the scenes. They make judgements from the evidence available to them, and that evidence often consists of tiny details.
 
 A spelling mistake in an important message, an unresolved template variable in an automated email, a broken link, an error message that blames the customer, or a form that asks the same question twice can each appear trivial.
 
@@ -160,7 +153,7 @@ Customers reasonably assume that visible sloppiness may be evidence of invisible
 
 First impressions matter because the small things are often evidence of the big things. They also help determine how big those things eventually become.
 
-## Your customer can fire you
+### Your customer can fire you
 
 For an external service provider, the idea that a customer can leave is obvious. Inside a company, it is easier to forget.
 
@@ -172,25 +165,17 @@ They can minimise their engagement with you. They can buy around you, build arou
 
 They can escalate until responsibility is moved elsewhere. Senior leaders can reorganise the company around you.
 
-Sometimes being fired internally looks like losing a platform. Sometimes it looks like outsourcing. Sometimes your team continues to exist, but the rest of the organisation stops trusting it with anything important.
-
-This is why I prefer the word customer to user.
+Sometimes being fired internally looks like losing a platform. Sometimes it looks like outsourcing. Sometimes your team continues to exist, but the rest of the organisation stops trusting it with anything important. This is why I prefer the word customer to user.
 
 User defines somebody by their interaction with a system. Customer keeps the focus on the outcome they are trying to achieve and the quality of the service they receive.
 
-The language changes the questions you ask. Are we solving the right problem? Was the experience good? Would they choose us again? Would they recommend us? Did we make them more successful?
+The language changes the questions you ask. Are we solving the right problem? Was the experience good? Would they choose us again? Would they recommend us? Did we make them more successful? Those are healthier questions than asking whether a ticket technically met its service-level agreement.
 
-Those are healthier questions than asking whether a ticket technically met its service-level agreement.
-
-An SLA can tell you that the organisation responded within four hours. It cannot tell you whether the response was useful, whether the customer had to explain the problem three times, or whether the issue passed through four teams before reaching somebody who could help.
-
-So measure the experience as well as the process.
+An SLA can tell you that the organisation responded within four hours. It cannot tell you whether the response was useful, whether the customer had to explain the problem three times, or whether the issue passed through four teams before reaching somebody who could help. So measure the experience as well as the process.
 
 Touchpoint measures such as transactional NPS are much better at this. You ask a question or two immediately after a real interaction, while the person still remembers what happened and can tell you which part of it was painful.
 
-The value is in the frequency and the volume. An annual relationship survey gives you a single, heavily averaged verdict, usually months after the events that formed it and usually from the people with the strongest feelings. A touchpoint measure gives you a continuous pulse, in enough volume to see the pattern by team, by service, by request type, and over time.
-
-It tells you that something changed in March rather than telling you next January that people are unhappy.
+The value is in the frequency and the volume. An annual relationship survey gives you a single, heavily averaged verdict, usually months after the events that formed it and usually from the people with the strongest feelings. A touchpoint measure gives you a continuous pulse, in enough volume to see the pattern by team, by service, by request type, and over time. It tells you that something changed in March rather than telling you next January that people are unhappy.
 
 The free-text comment is often worth more than the score. People will describe exactly where the journey hurt if you ask them while it is still fresh.
 
@@ -198,7 +183,7 @@ Be careful what you do with it. The moment a score becomes a target, people star
 
 Do not mistake compliance with your process for success in the eyes of the customer.
 
-## Do not make your problems the customer's problems
+### Do not make your problems the customer's problems
 
 This is one of the most common failures in service design.
 
@@ -212,15 +197,21 @@ Asking an employee to confirm their employee number, manager, department, device
 
 The phrase "our process requires" should always make us suspicious. Sometimes the requirement is legitimate. Quite often, it is simply an old decision nobody has challenged.
 
+I went to Center Parcs last week. Overall, amazing family holiday. But every activity required us to complete a medical form for every one of us. And we all got weighed multiple times through the week. One of the events even had an online medical form they direct you to in advance but then made you do it on paper anyway as they didn't have a computer to go get it.
+
+Talk about making your problems your customers' problems! It's not like you're going to wildly change weight one day to the next. All of this could have been done at the first activity that needed it and then carried through them all without rework.
+
+I can't imagine they designed the system while thinking "you know what would be a great experience? Have them fill in a total of more than 40 forms while they are here".
+
+This is an obvious tell of a system not being experienced by the people responsible for overall design.
+
 Good service providers do the joining up. They reconcile the systems, find the correct owner, and carry context between teams.
 
 That work can be difficult and expensive. It is also part of the value being provided.
 
 Customers should not have to perform unpaid systems integration on your behalf.
 
-This is also why user experience matters far beyond the appearance of software. User experience is the complete experience of attempting to achieve something through your service.
-
-It includes the forms, support processes, meetings, invoices, contracts, instructions, and automated messages.
+This is also why user experience matters far beyond the appearance of software. User experience is the complete experience of attempting to achieve something through your service. It includes the forms, support processes, meetings, invoices, contracts, instructions, and automated messages.
 
 Where does the customer begin? Do they understand what is being asked? Does the service behave as they expect? What happens when they make a mistake? Can they tell whether something worked, and do they know what will happen next?
 
@@ -234,15 +225,275 @@ If you are not good at it, partner with somebody who is and give them permission
 
 Do not bring them in at the end to apply a coat of UX paint.
 
-## Work hard and be nice to people
+## Design the system, not the symptom
 
-Years ago, Rob came back from a shop in Shoreditch with a poster that said, "Work hard and be nice to people."
+### Think in systems
 
-It is difficult to improve on that as a philosophy for doing business.
+Most business problems are not isolated events. They are products of a system.
 
-Working hard while treating people badly creates a culture of ego, fear, and burnout. Being nice without doing the work creates a pleasant but ineffective organisation.
+A missed target may be an individual performance problem. It may also be the predictable result of incentives, workload, unclear ownership, poor information, or a process that rewards the wrong behaviour.
 
-You need both.
+Fixing the person without fixing the system often means the same problem returns with a different person attached to it.
+
+Thinking in systems means looking beyond the immediate symptom. Ask what conditions produced the outcome, what behaviour the system encourages, and where information stops flowing.
+
+Look for where one part has been optimised at the expense of the whole. Think about what unintended behaviour your proposed solution might create.
+
+This matters particularly inside large organisations. Individual teams frequently make perfectly rational decisions that combine to create an irrational customer experience.
+
+Every department protects its own capacity with another approval. Every function creates its own intake form. Every system demands its own copy of the data.
+
+Each team meets its local target while the customer carries the accumulated weight of all that local optimisation.
+
+The Cynefin framework is one of the most useful tools I have found for thinking about how to respond to different kinds of problems.
+
+Its value is not in giving every situation a clever label. It is in recognising that different conditions require different methods.
+
+Some problems are clear enough that established practice, standardisation, and automation are appropriate. Some are complicated and require expertise and analysis.
+
+Some are complex, with cause and effect becoming clear only in retrospect, so progress depends on experiments, feedback, and adaptation. Some situations are chaotic and require immediate action to create enough stability for proper understanding to begin.
+
+A common management failure is to use the same approach everywhere.
+
+We apply rigid processes to complex problems. We experiment where good practice is already well established. We commission lengthy analysis during a crisis that requires immediate action.
+
+Understanding the kind of problem you are facing should come before choosing the method for solving it.
+
+Systems thinking also requires humility. A result that looks irrational from where you are standing may make perfect sense once you understand the wider system that produced it.
+
+### Understand the load-bearing walls
+
+Imagine somebody buying an old house and deciding to open up the ground floor.
+
+There is a wall in the middle of a room that seems inconvenient. Nobody can explain why it is there and there is no obvious reason not to remove it.
+
+The new owner knocks it down and discovers, rather late in the process, that it was holding up everything above it.
+
+Businesses contain load-bearing walls too. They are the odd approval, the strangely divided responsibility, the manual check, the team boundary, or the architectural decision that no longer seems to make sense.
+
+Somebody new takes ownership, sees an apparently irrational arrangement, and quite reasonably decides to simplify it.
+
+Sometimes they are right. The arrangement may be outdated, badly conceived, or the result of a lazy decision made years ago. It may also be an intentional compromise that is carrying a load nobody has noticed.
+
+Chesterton's fence is another way of expressing the same idea. You encounter a fence across a field and cannot see why anybody put it there.
+
+Your lack of understanding is not, by itself, a reason to remove it. It is a reason to study the fence until you understand what problem it was intended to solve.
+
+Once you understand the purpose, you can decide whether that purpose still matters and whether the fence remains the right answer.
+
+When teams change or responsibilities pass between people, do not begin from the assumption that those who came before you were clueless.
+
+Respect the possibility that they were responding to information, constraints, and trade-offs that are no longer visible.
+
+Study why the decision was made. Look for the documentation, speak to the people who were there, and examine what was happening at the time.
+
+If you cannot find the explanation, study harder and try to reconstruct it.
+
+The absence of documentation is not proof that there was no reasoning.
+
+This does not mean preserving every inherited process through misplaced reverence. Organisations accumulate plenty of nonsense. It means understanding something before changing it, particularly where the consequences might travel further than the change itself.
+
+A decision that appears inefficient may have been protecting reliability. A duplicated responsibility may have been compensating for a control weakness. A manual step may exist because an automated one previously caused damage.
+
+The original answer may no longer be correct, but the question it was answering may still exist.
+
+The best defence is to preserve the reasoning behind decisions while the people who made them can still remember it.
+
+One useful method is the [Y-Statement](https://socadk.github.io/design-practice-repository/artifact-templates/DPR-ArchitecturalDecisionRecordYForm.html). The structure is roughly this: in the context of a particular situation, facing a particular concern, we decided to take one course of action rather than the alternatives, to achieve a desired outcome, while accepting a stated downside.
+
+The final part matters. Real decisions usually involve a trade-off.
+
+Recording only what was chosen makes the decision appear more obvious and absolute than it really was. Recording what you knowingly accepted helps the next person understand the circumstances under which the decision might need to change.
+
+Write down why, not just what.
+
+Assume that somebody else will eventually inherit your house. Label the load-bearing walls before they arrive with a sledgehammer.
+
+### Work in the open
+
+One of the worst patterns I see in modern organisations is important work and decision-making disappearing into private Slack channels and direct messages.
+
+If you use Slack, favour public channels. Celebrate having a high ratio of public channels to private ones, and an even higher ratio of channel conversations to direct messages.
+
+Work conducted in private is work the organisation is likely to lose.
+
+The immediate participants may remember the conversation, but everybody else sees only the eventual outcome. The context, alternatives, disagreement, and reasoning disappear.
+
+Months later, somebody encounters the result and cannot understand why it exists. We have created another unexplained fence and another apparently pointless wall.
+
+There are legitimate reasons for working privately. Personal matters, commercially sensitive discussions, security incidents, and genuinely confidential subjects need appropriate protection.
+
+Privacy should be a deliberate control applied for a reason. It should not be the default setting for ordinary work.
+
+My friend and former colleague Jesse Taylor once captured the question brilliantly: "What are they afraid of?" It is worth asking whenever a team habitually works behind closed doors.
+
+What specifically would go wrong if colleagues could see this discussion?
+
+Sometimes there is a good answer. Often there is only habit, hierarchy, or discomfort with allowing unfinished thinking to be visible.
+
+Working in the open does not mean every employee must read everything. It means the work is available to the people who need it, including people you have not yet met.
+
+Assume you will eventually leave the business. Assume somebody new will inherit the service, system, or decision you are working on.
+
+Assume they will need to search for your reasoning without knowing your name, the date of the conversation, or which private group contained it.
+
+Could they find it? Could they understand how you reached the decision, or would they find only the final artefact and be left to guess?
+
+Closed channels and direct messages create a similar problem to the person who never takes time off. Knowledge remains concentrated around particular individuals.
+
+The organisation appears to function while they are present, but struggles to reproduce their understanding without them.
+
+This can happen innocently. Direct messages feel fast. Private groups feel safe. A small number of familiar people can reach decisions quickly without explaining all the context to everybody else.
+
+The price is paid later through repeated conversations, duplicated work, and decisions that have to be rediscovered.
+
+Work in the open. Put decisions somewhere durable and searchable. Summarise what was agreed and capture why.
+
+Link the conversation to the resulting work and the resulting work back to the decision.
+
+Organisational memory does not happen automatically. You have to design for it.
+
+### Use automation as a design constraint
+
+There is familiar advice that you should never automate a broken process. It is directionally sensible, but too easily repeated.
+
+Attempting to automate a process is often how you discover that it is broken.
+
+Automation is intolerant of ambiguity.
+
+A person can look at an incomplete request and infer what the customer probably meant. They can remember that requests from a particular department normally go to one person unless they involve finance, in which case they go somewhere else, except at quarter end.
+
+Software cannot operate on folklore.
+
+To automate a process, you have to define the inputs, ownership, decisions, exceptions, and desired outcome. You have to confront the places where the organisation depends on context that exists only in somebody's head.
+
+Automation can therefore be a forcing function for better process and systems design.
+
+The objective is not to reproduce every existing step in software. It is to question the steps.
+
+Do we need this approval? Why are we asking for information we already have? Why does the work pass through three queues? Why does a person have to decide which team receives it?
+
+Bad automation makes a poor process move faster. Good automation forces you to define a better process.
+
+This principle matters even where you do not ultimately automate everything. The attempt forces clarity. It makes the team agree on ownership, inputs, and outcomes. It reveals exceptions that have quietly become the normal way of operating.
+
+Where the process cannot be clearly described, it is unlikely to be consistently performed.
+
+### Make human routing optional
+
+A person whose job is to read incoming work and decide where to send it is often compensating for a service that has not been designed properly.
+
+That role may be necessary as a temporary safety net. It should not be a permanent architectural requirement.
+
+Human routers become bottlenecks. They introduce delay, inconsistency, and dependency.
+
+When they are experienced, they can make the process look remarkably effective because they know who really owns something and which wording indicates the underlying problem.
+
+That knowledge is valuable. It should be captured rather than permanently rented from one person's memory.
+
+Design the service so that work can identify its own destination wherever reasonably possible. Use structured information, known customer context, service ownership, classification rules, and automation.
+
+Where certainty is not possible, use a confidence threshold and send the genuinely ambiguous cases to a person.
+
+Human routing should be the exception path, not the happy path.
+
+This matters even more as AI becomes part of service delivery. AI can help interpret messy language, enrich requests, and recommend destinations, but it should not become a more expensive disguise for an undefined ownership model.
+
+The system still needs to know who is responsible for what.
+
+People are most valuable when they are exercising judgement, showing empathy, resolving genuine ambiguity, and making decisions that carry consequences.
+
+Reading a form and forwarding it to another queue is not meaningful human involvement.
+
+Build systems that can move work by themselves. Keep people available for the moments that deserve them.
+
+## Mind what accumulates
+
+### Never rescue a process silently
+
+One of the most dangerous things a capable team can do is quietly prevent a broken system from ever appearing broken.
+
+People fill in missing information, chase approvals, manually route work, and remember all the unwritten exceptions. They correct malformed requests and reconcile conflicting records without making any fuss.
+
+The customer sees a service that just about works. Management sees acceptable performance. The people holding it together see the truth, but they are too busy compensating for the problems to fix them.
+
+I am not suggesting you stop rescuing the customer. Everything else in this article argues that you should, and a service that deliberately lets somebody down to prove an internal point has just invented a new way of making its problems their problems.
+
+The difficulty is that the rescue usually appears to cost nothing and leaves no trace. Somebody spots the malformed request, knows from experience which team it actually belongs to, forwards it, and gets on with their day. The customer is served, the report looks fine, and the thing that caused it is exactly as broken tomorrow morning.
+
+So do the rescue, and then make it expensive to ignore. Record what happened. Note what the person had to know and what they had to do, because that is a fairly precise specification for whatever should have handled it instead. Count how often it happens and put that number alongside the others you review each week.
+
+Work with a number attached to it gets prioritised. Work that lives in somebody's head and costs them ten minutes a day does not, because those ten minutes belong to them rather than to the business.
+
+Heroics are useful during an incident. They are a terrible operating model.
+
+If you want to understand how much of your service depends on people covering for it, you can go looking on purpose, at a time you choose rather than one a customer chooses for you. Send a badly formed request through and see where it ends up. Ask the person who always knows to stay out of it for a fortnight.
+
+Holidays do this for nothing. Very little reveals an undocumented process quite like the person who holds it being genuinely unavailable, which is one of the reasons I care so much about people taking their leave.
+
+The aim is not to eliminate human involvement. It is to stop spending human judgement on work that only requires human memory, persistence, or pattern matching.
+
+### Do not become over-leveraged
+
+There is a reflex in some teams that treats technical debt as inherently shameful, as though any of it existing at all is evidence that somebody did their job badly.
+
+I do not think that is right. It is far more useful to think about technical debt the way you think about financial debt.
+
+Debt is a tool. It is a large part of what drives an economy and, used sensibly, it is what allows a business to do something this year rather than in three years' time. Taking some on is usually evidence of a deliberate choice about speed, not evidence of carelessness.
+
+What people forget is what happens after the decision. When you create something, you own it. It has to be maintained, patched, understood, documented, explained to whoever arrives next, and eventually replaced. Nothing you build exists for free, and the bill does not arrive on the day you build it. It arrives every month afterwards, for as long as the thing survives.
+
+There is nothing wrong with having a mortgage on your house. What is not fine is having a mortgage you cannot afford.
+
+An over-leveraged technical team behaves much like an over-leveraged household. The weight starts to show, and it tends to show in one of two ways. Either the team can no longer move at a sensible pace, because every change has to be threaded carefully through things nobody wants to touch, or the quality of the work starts to slip because there is no room left to do it properly.
+
+It also compounds. The more you are carrying, the more separate things demand attention, and the more your people spend their days switching between them rather than finishing any of them. Context switching is a tax you pay on top of the interest.
+
+Refusing to make these decisions does not simply slow the work down, it chokes the creativity out of a team. Nobody offers up the interesting idea when they already know there is no room to build it, and watching your week disappear into servicing decisions somebody else avoided making is thoroughly demoralising. That is a more expensive loss than the debt itself, and a much harder one to reverse.
+
+So be selective about what you take on, and be equally intentional about what you are prepared to remove. Most organisations are considerably better at adding than they are at subtracting.
+
+Have one CRM, not three. Pick Microsoft or Google, not both. Teams or Zoom for your meetings, not both. Normalise where you can and actually make the call, because the alternative is quietly agreeing to feed all of it forever.
+
+The Y-Statement from earlier does the same job here. A decision recorded properly, including the downside you knowingly accepted, is a decision you can still defend a year later when somebody asks why you did not do the other thing.
+
+A good decision-making process does not only make you comfortable committing to something. It makes you comfortable deciding, deliberately and on the record, not to do something else.
+
+### Don't stumble the wrong side of a moat
+
+There is a pattern worth recognising in the way software vendors grow inside your business.
+
+They arrive with one thing that is genuinely good, and that thing is usually displaceable. You could swap it out next year if you decided to. Then they add the features that make leaving difficult, and those features are rarely the ones you originally bought.
+
+Come for the X, stay for the Y.
+
+Some examples that are top of mind for me at the moment. Anthropic: come for the model, stay for the routines and Claude Design. Workboard: come for the OKRs, stay for the 1:1s. Miro: come for the multiplayer whiteboard, stay for the prototypes and wireframes. Slack: come for the chat, stay for the enormous ChatOps ecosystem and the growing pile of AI features.
+
+To be clear, I have no objection to tools that do lots of things. Those are all good products, and breadth is frequently exactly what you want.
+
+What I dislike is the tool you allow through the door for one purpose, which then creeps unintentionally into an increasing number of corners of your business. Nobody sits down and decides to do this. It happens one sensible convenience at a time.
+
+Every one of those small conveniences makes the relationship a little stickier. That is fine while the tool is the best available answer. It becomes a problem when the tool grows, as tools do, and the part you depend on starts to lag behind. By that point you are no longer making a decision about one product. You are making a decision about nine things you had not really noticed you were buying.
+
+It also quietly distorts how you assess everything else. You glance at something new and think, well, our existing tool does that, so we do not need it. Sometimes that is true. But you should be free to consider all of your options, and "we already own something that technically does this" is not the same statement as "we already own something that does this well".
+
+I think of those all-in-one televisions you used to be able to buy. A television with a built-in DVD player, a VHS player, and a little clock on the front. One device that does everything! Badly. With the most confusing remote control you have ever held.
+
+A specific tool that does one thing will almost always do that one thing better. That does not mean you should go and buy forty of them, only that "it is already included" is weak evidence on its own.
+
+All of this is far easier to describe than to do. Vendors work extremely hard at stickiness because it is their business model, and the worst thing that can happen to a SaaS company is account reduction. The packaging, the pricing, and the roadmap are all designed to make removing anything feel unreasonable.
+
+So stay on top of it. Look at your ecosystem as a whole rather than one renewal at a time, and make the calls intentionally. Sometimes consolidating is exactly right and you should do it enthusiastically. Sometimes it is not, and the specialist tool has earned its place on the invoice.
+
+The point is to decide, rather than to arrive somewhere by accumulation.
+
+## Look after the people
+
+### Work hard and be nice to people
+
+Years ago, Rob came back from a shop in Shoreditch with a poster that said, "Work hard and be nice to people." It is difficult to improve on that as a philosophy for doing business.
+
+Working hard while treating people badly creates a culture of ego, fear, and burnout. Being nice without doing the work creates a pleasant but ineffective organisation. You need both.
 
 Being nice does not mean avoiding difficult conversations, tolerating poor performance, or agreeing to every request. It means treating people with respect. It means being direct without being cruel and remembering that the person at the other end of a difficult situation is still a person.
 
@@ -278,293 +529,13 @@ The respect has to work both ways. Sales must respect the people who fulfil the 
 
 Acquiring, serving, and retaining a customer are not separate activities. They are parts of the same system.
 
-## Think in systems
+### Use a meeting structure that works
 
-Most business problems are not isolated events. They are products of a system.
-
-A missed target may be an individual performance problem. It may also be the predictable result of incentives, workload, unclear ownership, poor information, or a process that rewards the wrong behaviour.
-
-Fixing the person without fixing the system often means the same problem returns with a different person attached to it.
-
-Thinking in systems means looking beyond the immediate symptom. Ask what conditions produced the outcome, what behaviour the system encourages, and where information stops flowing.
-
-Look for where one part has been optimised at the expense of the whole. Think about what unintended behaviour your proposed solution might create.
-
-This matters particularly inside large organisations. Individual teams frequently make perfectly rational decisions that combine to create an irrational customer experience.
-
-Every department protects its own capacity with another approval. Every function creates its own intake form. Every system demands its own copy of the data.
-
-Each team meets its local target while the customer carries the accumulated weight of all that local optimisation.
-
-The Cynefin framework is one of the most useful tools I have found for thinking about how to respond to different kinds of problems.
-
-Its value is not in giving every situation a clever label. It is in recognising that different conditions require different methods.
-
-Some problems are clear enough that established practice, standardisation, and automation are appropriate. Some are complicated and require expertise and analysis.
-
-Some are complex, with cause and effect becoming clear only in retrospect, so progress depends on experiments, feedback, and adaptation. Some situations are chaotic and require immediate action to create enough stability for proper understanding to begin.
-
-A common management failure is to use the same approach everywhere.
-
-We apply rigid processes to complex problems. We experiment where good practice is already well established. We commission lengthy analysis during a crisis that requires immediate action.
-
-Understanding the kind of problem you are facing should come before choosing the method for solving it.
-
-Systems thinking also requires humility. A result that looks irrational from where you are standing may make perfect sense once you understand the wider system that produced it.
-
-## Understand the load-bearing walls
-
-Imagine somebody buying an old house and deciding to open up the ground floor.
-
-There is a wall in the middle of a room that seems inconvenient. Nobody can explain why it is there and there is no obvious reason not to remove it.
-
-The new owner knocks it down and discovers, rather late in the process, that it was holding up everything above it.
-
-Businesses contain load-bearing walls too.
-
-They are the odd approval, the strangely divided responsibility, the manual check, the team boundary, or the architectural decision that no longer seems to make sense.
-
-Somebody new takes ownership, sees an apparently irrational arrangement, and quite reasonably decides to simplify it.
-
-Sometimes they are right. The arrangement may be outdated, badly conceived, or the result of a lazy decision made years ago.
-
-It may also be an intentional compromise that is carrying a load nobody has noticed.
-
-Chesterton's fence is another way of expressing the same idea. You encounter a fence across a field and cannot see why anybody put it there.
-
-Your lack of understanding is not, by itself, a reason to remove it. It is a reason to study the fence until you understand what problem it was intended to solve.
-
-Once you understand the purpose, you can decide whether that purpose still matters and whether the fence remains the right answer.
-
-When teams change or responsibilities pass between people, do not begin from the assumption that those who came before you were clueless.
-
-Respect the possibility that they were responding to information, constraints, and trade-offs that are no longer visible.
-
-Study why the decision was made. Look for the documentation, speak to the people who were there, and examine what was happening at the time.
-
-If you cannot find the explanation, study harder and try to reconstruct it.
-
-The absence of documentation is not proof that there was no reasoning.
-
-This does not mean preserving every inherited process through misplaced reverence. Organisations accumulate plenty of nonsense.
-
-It means understanding something before changing it, particularly where the consequences might travel further than the change itself.
-
-A decision that appears inefficient may have been protecting reliability. A duplicated responsibility may have been compensating for a control weakness. A manual step may exist because an automated one previously caused damage.
-
-The original answer may no longer be correct, but the question it was answering may still exist.
-
-The best defence is to preserve the reasoning behind decisions while the people who made them can still remember it.
-
-One useful method is the [Y-Statement](https://socadk.github.io/design-practice-repository/artifact-templates/DPR-ArchitecturalDecisionRecordYForm.html). The structure is roughly this: in the context of a particular situation, facing a particular concern, we decided to take one course of action rather than the alternatives, to achieve a desired outcome, while accepting a stated downside.
-
-The final part matters. Real decisions usually involve a trade-off.
-
-Recording only what was chosen makes the decision appear more obvious and absolute than it really was. Recording what you knowingly accepted helps the next person understand the circumstances under which the decision might need to change.
-
-Write down why, not just what.
-
-Assume that somebody else will eventually inherit your house. Label the load-bearing walls before they arrive with a sledgehammer.
-
-## Work in the open
-
-One of the worst patterns I see in modern organisations is important work and decision-making disappearing into private Slack channels and direct messages.
-
-If you use Slack, favour public channels. Celebrate having a high ratio of public channels to private ones, and an even higher ratio of channel conversations to direct messages.
-
-Work conducted in private is work the organisation is likely to lose.
-
-The immediate participants may remember the conversation, but everybody else sees only the eventual outcome. The context, alternatives, disagreement, and reasoning disappear.
-
-Months later, somebody encounters the result and cannot understand why it exists. We have created another unexplained fence and another apparently pointless wall.
-
-There are legitimate reasons for working privately. Personal matters, commercially sensitive discussions, security incidents, and genuinely confidential subjects need appropriate protection.
-
-Privacy should be a deliberate control applied for a reason. It should not be the default setting for ordinary work.
-
-My friend and former colleague Jesse Taylor once captured the question brilliantly: "What are they afraid of?"
-
-It is worth asking whenever a team habitually works behind closed doors.
-
-What specifically would go wrong if colleagues could see this discussion?
-
-Sometimes there is a good answer. Often there is only habit, hierarchy, or discomfort with allowing unfinished thinking to be visible.
-
-Working in the open does not mean every employee must read everything. It means the work is available to the people who need it, including people you have not yet met.
-
-Assume you will eventually leave the business. Assume somebody new will inherit the service, system, or decision you are working on.
-
-Assume they will need to search for your reasoning without knowing your name, the date of the conversation, or which private group contained it.
-
-Could they find it? Could they understand how you reached the decision, or would they find only the final artefact and be left to guess?
-
-Closed channels and direct messages create a similar problem to the person who never takes time off. Knowledge remains concentrated around particular individuals.
-
-The organisation appears to function while they are present, but struggles to reproduce their understanding without them.
-
-This can happen innocently. Direct messages feel fast. Private groups feel safe. A small number of familiar people can reach decisions quickly without explaining all the context to everybody else.
-
-The price is paid later through repeated conversations, duplicated work, and decisions that have to be rediscovered.
-
-Work in the open. Put decisions somewhere durable and searchable. Summarise what was agreed and capture why.
-
-Link the conversation to the resulting work and the resulting work back to the decision.
-
-Organisational memory does not happen automatically. You have to design for it.
-
-## Never rescue a process silently
-
-One of the most dangerous things a capable team can do is quietly prevent a broken system from ever appearing broken.
-
-People fill in missing information, chase approvals, manually route work, and remember all the unwritten exceptions. They correct malformed requests and reconcile conflicting records without making any fuss.
-
-The customer sees a service that just about works. Management sees acceptable performance. The people holding it together see the truth, but they are too busy compensating for the problems to fix them.
-
-I am not suggesting you stop rescuing the customer. Everything else in this article argues that you should, and a service that deliberately lets somebody down to prove an internal point has just invented a new way of making its problems their problems.
-
-The difficulty is that the rescue usually appears to cost nothing and leaves no trace. Somebody spots the malformed request, knows from experience which team it actually belongs to, forwards it, and gets on with their day. The customer is served, the report looks fine, and the thing that caused it is exactly as broken tomorrow morning.
-
-So do the rescue, and then make it expensive to ignore. Record what happened. Note what the person had to know and what they had to do, because that is a fairly precise specification for whatever should have handled it instead. Count how often it happens and put that number alongside the others you review each week.
-
-Work with a number attached to it gets prioritised. Work that lives in somebody's head and costs them ten minutes a day does not, because those ten minutes belong to them rather than to the business.
-
-Heroics are useful during an incident. They are a terrible operating model.
-
-If you want to understand how much of your service depends on people covering for it, you can go looking on purpose, at a time you choose rather than one a customer chooses for you. Send a badly formed request through and see where it ends up. Ask the person who always knows to stay out of it for a fortnight.
-
-Holidays do this for nothing. Very little reveals an undocumented process quite like the person who holds it being genuinely unavailable, which is one of the reasons I care so much about people taking their leave.
-
-The aim is not to eliminate human involvement. It is to stop spending human judgement on work that only requires human memory, persistence, or pattern matching.
-
-## Do not become over-leveraged
-
-There is a reflex in some teams that treats technical debt as inherently shameful, as though any of it existing at all is evidence that somebody did their job badly.
-
-I do not think that is right. It is far more useful to think about technical debt the way you think about financial debt.
-
-Debt is a tool. It is a large part of what drives an economy and, used sensibly, it is what allows a business to do something this year rather than in three years' time. Taking some on is usually evidence of a deliberate choice about speed, not evidence of carelessness.
-
-What people forget is what happens after the decision. When you create something, you own it. It has to be maintained, patched, understood, documented, explained to whoever arrives next, and eventually replaced.
-
-Nothing you build exists for free, and the bill does not arrive on the day you build it. It arrives every month afterwards, for as long as the thing survives.
-
-There is nothing wrong with having a mortgage on your house. What is not fine is having a mortgage you cannot afford.
-
-An over-leveraged technical team behaves much like an over-leveraged household. The weight starts to show, and it tends to show in one of two ways.
-
-Either the team can no longer move at a sensible pace, because every change has to be threaded carefully through things nobody wants to touch, or the quality of the work starts to slip because there is no room left to do it properly.
-
-It also compounds. The more you are carrying, the more separate things demand attention, and the more your people spend their days switching between them rather than finishing any of them. Context switching is a tax you pay on top of the interest.
-
-Refusing to make these decisions does not simply slow the work down, it chokes the creativity out of a team.
-
-Nobody offers up the interesting idea when they already know there is no room to build it, and watching your week disappear into servicing decisions somebody else avoided making is thoroughly demoralising. That is a more expensive loss than the debt itself, and a much harder one to reverse.
-
-So be selective about what you take on, and be equally intentional about what you are prepared to remove. Most organisations are considerably better at adding than they are at subtracting.
-
-Have one CRM, not three. Pick Microsoft or Google, not both. Teams or Zoom for your meetings, not both. Normalise where you can and actually make the call, because the alternative is quietly agreeing to feed all of it forever.
-
-The Y-Statement from earlier does the same job here. A decision recorded properly, including the downside you knowingly accepted, is a decision you can still defend a year later when somebody asks why you did not do the other thing.
-
-A good decision-making process does not only make you comfortable committing to something. It makes you comfortable deciding, deliberately and on the record, not to do something else.
-
-## Don't stumble the wrong side of a moat
-
-There is a pattern worth recognising in the way software vendors grow inside your business.
-
-They arrive with one thing that is genuinely good, and that thing is usually displaceable. You could swap it out next year if you decided to. Then they add the features that make leaving difficult, and those features are rarely the ones you originally bought.
-
-Come for the X, stay for the Y.
-
-Some examples that are top of mind for me at the moment. Anthropic: come for the model, stay for the routines and Claude Design. Workboard: come for the OKRs, stay for the 1:1s. Miro: come for the multiplayer whiteboard, stay for the prototypes and wireframes. Slack: come for the chat, stay for the enormous ChatOps ecosystem and the growing pile of AI features.
-
-To be clear, I have no objection to tools that do lots of things. Those are all good products, and breadth is frequently exactly what you want.
-
-What I dislike is the tool you allow through the door for one purpose, which then creeps unintentionally into an increasing number of corners of your business. Nobody sits down and decides to do this. It happens one sensible convenience at a time.
-
-Every one of those small conveniences makes the relationship a little stickier. That is fine while the tool is the best available answer.
-
-It becomes a problem when the tool grows, as tools do, and the part you depend on starts to lag behind. By that point you are no longer making a decision about one product. You are making a decision about nine things you had not really noticed you were buying.
-
-It also quietly distorts how you assess everything else. You glance at something new and think, well, our existing tool does that, so we do not need it. Sometimes that is true. But you should be free to consider all of your options, and "we already own something that technically does this" is not the same statement as "we already own something that does this well".
-
-I think of those all-in-one televisions you used to be able to buy. A television with a built-in DVD player, a VHS player, and a little clock on the front. One device that does everything! Badly. With the most confusing remote control you have ever held.
-
-A specific tool that does one thing will almost always do that one thing better. That does not mean you should go and buy forty of them, only that "it is already included" is weak evidence on its own.
-
-All of this is far easier to describe than to do. Vendors work extremely hard at stickiness because it is their business model, and the worst thing that can happen to a SaaS company is account reduction. The packaging, the pricing, and the roadmap are all designed to make removing anything feel unreasonable.
-
-So stay on top of it. Look at your ecosystem as a whole rather than one renewal at a time, and make the calls intentionally. Sometimes consolidating is exactly right and you should do it enthusiastically. Sometimes it is not, and the specialist tool has earned its place on the invoice.
-
-The point is to decide, rather than to arrive somewhere by accumulation.
-
-## Use automation as a design constraint
-
-There is familiar advice that you should never automate a broken process. It is directionally sensible, but too easily repeated.
-
-Attempting to automate a process is often how you discover that it is broken.
-
-Automation is intolerant of ambiguity.
-
-A person can look at an incomplete request and infer what the customer probably meant. They can remember that requests from a particular department normally go to one person unless they involve finance, in which case they go somewhere else, except at quarter end.
-
-Software cannot operate on folklore.
-
-To automate a process, you have to define the inputs, ownership, decisions, exceptions, and desired outcome. You have to confront the places where the organisation depends on context that exists only in somebody's head.
-
-Automation can therefore be a forcing function for better process and systems design.
-
-The objective is not to reproduce every existing step in software. It is to question the steps.
-
-Do we need this approval? Why are we asking for information we already have? Why does the work pass through three queues? Why does a person have to decide which team receives it?
-
-Bad automation makes a poor process move faster. Good automation forces you to define a better process.
-
-This principle matters even where you do not ultimately automate everything. The attempt forces clarity. It makes the team agree on ownership, inputs, and outcomes.
-
-It reveals exceptions that have quietly become the normal way of operating.
-
-Where the process cannot be clearly described, it is unlikely to be consistently performed.
-
-## Make human routing optional
-
-A person whose job is to read incoming work and decide where to send it is often compensating for a service that has not been designed properly.
-
-That role may be necessary as a temporary safety net. It should not be a permanent architectural requirement.
-
-Human routers become bottlenecks. They introduce delay, inconsistency, and dependency.
-
-When they are experienced, they can make the process look remarkably effective because they know who really owns something and which wording indicates the underlying problem.
-
-That knowledge is valuable. It should be captured rather than permanently rented from one person's memory.
-
-Design the service so that work can identify its own destination wherever reasonably possible. Use structured information, known customer context, service ownership, classification rules, and automation.
-
-Where certainty is not possible, use a confidence threshold and send the genuinely ambiguous cases to a person.
-
-Human routing should be the exception path, not the happy path.
-
-This matters even more as AI becomes part of service delivery. AI can help interpret messy language, enrich requests, and recommend destinations, but it should not become a more expensive disguise for an undefined ownership model.
-
-The system still needs to know who is responsible for what.
-
-People are most valuable when they are exercising judgement, showing empathy, resolving genuine ambiguity, and making decisions that carry consequences.
-
-Reading a form and forwarding it to another queue is not meaningful human involvement.
-
-Build systems that can move work by themselves. Keep people available for the moments that deserve them.
-
-## Use a meeting structure that works
-
-Most meetings are bad because they have not really been designed.
-
-They mix status reporting, problem-solving, announcements, and decisions into an unstructured conversation.
+Most meetings are bad because they have not really been designed. They mix status reporting, problem-solving, announcements, and decisions into an unstructured conversation.
 
 The first topic consumes half the available time, the most important issue is raised with five minutes remaining, and everybody leaves with a slightly different understanding of what was agreed.
 
-Use the EOS Level 10 Meeting structure.
-
-I have used it for around fifteen years and genuinely believe it can change the working culture of a team.
+Use the EOS Level 10 Meeting structure. I have used it for around fifteen years and genuinely believe it can change the working culture of a team.
 
 It is normally presented as a leadership meeting, but the underlying structure works far more broadly. I have used it with operational teams, functional leadership groups, and people coming together around a shared body of work.
 
@@ -592,13 +563,11 @@ The structure only works when you respect it. If every issue is discussed the mo
 
 I have introduced a lot of people to properly run Level 10 meetings over the years. Almost every time, somebody remarks that it is one of the best meetings they have ever attended.
 
-Most recently, that was Mark Michelman and Matthew Davenport, when I began working with them on my team about a year ago.
-
-That reaction says less about the brilliance of one meeting format than it does about the very low standard people have learned to expect from meetings.
+Most recently, that was Mark Michelman and Matthew Davenport, when I began working with them on my team about a year ago. That reaction says less about the brilliance of one meeting format than it does about the very low standard people have learned to expect from meetings.
 
 Give meetings a purpose, a rhythm, and a method for reaching decisions. Respect everybody's time enough to design the meeting rather than merely scheduling it.
 
-## Take time off, and do it properly
+### Take time off, and do it properly
 
 Take your holiday.
 
@@ -616,9 +585,7 @@ I was building something, solving something, or carrying responsibility for some
 
 COVID rotated my priorities.
 
-Like many people, I was forced to stop and look differently at how I had been spending my time. I realised that I had missed a meaningful chunk of my children's lives by being so immersed in work.
-
-That is not time you can recover later.
+Like many people, I was forced to stop and look differently at how I had been spending my time. I realised that I had missed a meaningful chunk of my children's lives by being so immersed in work. That is not time you can recover later.
 
 Children do not pause while you finish an important period in your career. They do not stay the same age while you get through a difficult quarter, complete an acquisition, or wait for the business to become less demanding.
 
@@ -640,9 +607,7 @@ The point is not to pretend the evening work has no cost. It is to acknowledge t
 
 From Tuesday to Thursday I work from the office. On Friday I work from home and keep to UK hours.
 
-None of this is perfectly symmetrical. Balance rarely is.
-
-It is a deliberate arrangement that allows me to meet the responsibilities of a global role without making my family absorb an undefined and potentially unlimited amount of disruption.
+None of this is perfectly symmetrical. Balance rarely is. It is a deliberate arrangement that allows me to meet the responsibilities of a global role without making my family absorb an undefined and potentially unlimited amount of disruption.
 
 The important thing is that the boundaries are designed in advance. They are not renegotiated every time a meeting invitation arrives.
 
@@ -670,7 +635,7 @@ A rested person makes better decisions, treats people better, and is less likely
 
 Work matters. So does the life the work is meant to support.
 
-## A note on working from home
+### A note on working from home
 
 My own balance includes working from home on Monday and Friday, while spending Tuesday to Thursday in the office with my team. That arrangement is deliberate. I value the flexibility of working from home, but I have also become increasingly convinced that it carries a real cost to learning, relationships, and the development of teams.
 
@@ -686,7 +651,7 @@ One of my favourite parts of running businesses and teams is helping people disc
 
 I still believe in flexibility, and I use it myself. I simply no longer believe that full-time home working is an equivalent substitute for spending a meaningful part of the week together.
 
-## Scrutinise people who never leave
+### Scrutinise people who never leave
 
 People who refuse to take holiday are often praised for their dedication.
 
@@ -694,9 +659,7 @@ Be careful.
 
 My accounting lecturer at college, whose name I wish I could remember and think may have been Neil, once told us a story from his time working in audit.
 
-There was a groundskeeper at a cemetery who had not taken meaningful time off in years.
-
-He was dependable, knew how everything operated, and was always there to make sure things ran correctly.
+There was a groundskeeper at a cemetery who had not taken meaningful time off in years. He was dependable, knew how everything operated, and was always there to make sure things ran correctly.
 
 Then he was hospitalised after an accident.
 
@@ -710,17 +673,9 @@ This is an extreme and deliberately nefarious example. Most people who refuse to
 
 The underlying organisational risk is still real.
 
-Sometimes people make themselves indispensable because they cannot, or will not, build a machine that operates beyond them.
+Sometimes people make themselves indispensable because they cannot, or will not, build a machine that operates beyond them. They hold processes in their heads, become the only person with access to a system, and personally intervene whenever something goes wrong. They answer every question, approve every decision, and quietly compensate for weaknesses in the operation. This can happen without any bad intent.
 
-They hold processes in their heads, become the only person with access to a system, and personally intervene whenever something goes wrong.
-
-They answer every question, approve every decision, and quietly compensate for weaknesses in the operation.
-
-This can happen without any bad intent.
-
-In fact, it is often the most conscientious and productive people who create the greatest hidden risk. They care deeply, work incredibly hard, and solve problems before anybody else knows those problems exist.
-
-Their productivity shields the fragility beneath them.
+In fact, it is often the most conscientious and productive people who create the greatest hidden risk. They care deeply, work incredibly hard, and solve problems before anybody else knows those problems exist. Their productivity shields the fragility beneath them.
 
 At a glance, they appear to be your top performers. The work gets done, customers are happy, and problems disappear. The person appears irreplaceable.
 
@@ -736,13 +691,9 @@ Call it the bus problem, a single point of failure, or a bottleneck. The metapho
 
 A genuinely great performer does not merely produce an exceptional volume of work.
 
-They make the people and systems around them more capable. They document what they know, distribute authority, train successors, and reduce the organisation's dependence on their continued presence.
+They make the people and systems around them more capable. They document what they know, distribute authority, train successors, and reduce the organisation's dependence on their continued presence. Their absence may be felt, but it should not cause the machinery to stop.
 
-Their absence may be felt, but it should not cause the machinery to stop.
-
-Mandatory leave, proper handovers, and sensible job rotation are not signs that you distrust people. They are healthy controls.
-
-They expose undocumented work, weak segregation of duties, and responsibilities that have become dangerously concentrated in one person.
+Mandatory leave, proper handovers, and sensible job rotation are not signs that you distrust people. They are healthy controls. They expose undocumented work, weak segregation of duties, and responsibilities that have become dangerously concentrated in one person.
 
 Encourage people to take leave. Scrutinise those who consistently refuse.
 
@@ -754,11 +705,7 @@ The common thread through all of this is that service is not defined by the orga
 
 Service is what the customer experiences while trying to get something done.
 
-It is whether you made the journey easy and respected their time. It is whether you took ownership rather than exporting your complexity.
-
-It is whether the visible details inspired confidence and whether you were competent and decent when something went wrong.
-
-It is also whether you built a system that learns, or one that depends on good people repeatedly saving it.
+It is whether you made the journey easy and respected their time. It is whether you took ownership rather than exporting your complexity. It is whether the visible details inspired confidence and whether you were competent and decent when something went wrong. It is also whether you built a system that learns, or one that depends on good people repeatedly saving it.
 
 Whether you are selling a service to the outside world or providing one to colleagues inside a larger organisation, those are the things that determine whether people trust you.
 

--- a/src/content/posts/the-rules-i-try-to-do-business-by.mdx
+++ b/src/content/posts/the-rules-i-try-to-do-business-by.mdx
@@ -185,6 +185,14 @@ Do not mistake compliance with your process for success in the eyes of the custo
 
 ### Do not make your problems the customer's problems
 
+I went to Center Parcs last week. Overall, amazing family holiday. But every activity required us to complete a medical form for every one of us. And we all got weighed multiple times through the week. One of the events even had an online medical form they direct you to in advance but then made you do it on paper anyway as they didn't have a computer to go get it.
+
+Talk about making your problems your customers' problems! It's not like you're going to wildly change weight one day to the next. All of this could have been done at the first activity that needed it and then carried through them all without rework.
+
+I can't imagine they designed the system while thinking "you know what would be a great experience? Have them fill in a total of more than 40 forms while they are here".
+
+This is an obvious tell of a system not being experienced by the people responsible for overall design.
+
 This is one of the most common failures in service design.
 
 The organisation has fragmented systems, so the customer is asked for the same information repeatedly. A team has poor visibility, so the customer is asked to confirm something the company already knows.
@@ -196,14 +204,6 @@ None of those things is the customer's fault.
 Asking an employee to confirm their employee number, manager, department, device type, and office location may sound harmless. If all that information already exists inside your systems, you are asking the customer to compensate for your inability to retrieve it.
 
 The phrase "our process requires" should always make us suspicious. Sometimes the requirement is legitimate. Quite often, it is simply an old decision nobody has challenged.
-
-I went to Center Parcs last week. Overall, amazing family holiday. But every activity required us to complete a medical form for every one of us. And we all got weighed multiple times through the week. One of the events even had an online medical form they direct you to in advance but then made you do it on paper anyway as they didn't have a computer to go get it.
-
-Talk about making your problems your customers' problems! It's not like you're going to wildly change weight one day to the next. All of this could have been done at the first activity that needed it and then carried through them all without rework.
-
-I can't imagine they designed the system while thinking "you know what would be a great experience? Have them fill in a total of more than 40 forms while they are here".
-
-This is an obvious tell of a system not being experienced by the people responsible for overall design.
 
 Good service providers do the joining up. They reconcile the systems, find the correct owner, and carry context between teams.
 

--- a/src/content/posts/the-rules-i-try-to-do-business-by.mdx
+++ b/src/content/posts/the-rules-i-try-to-do-business-by.mdx
@@ -67,6 +67,8 @@ Customers should be able to describe the outcome they need. It is your job to wo
 
 ### Be the customer
 
+Do you ever think about what it's like to use your services? No, really though, do you ever actually go and use your services yourself?
+
 Use your own tools, systems, and processes.
 
 No, really, force yourself. Get hands on with everything you provide. Experience it all. And wear the hat of the most picky customer ever.

--- a/src/content/posts/the-rules-i-try-to-do-business-by.mdx
+++ b/src/content/posts/the-rules-i-try-to-do-business-by.mdx
@@ -9,6 +9,8 @@ import Callout from '../../components/Callout.astro';
 
 <Callout variant="neutral" icon="😤">
   I have realised while writing this that it's become a blend of "here's some things I've learned" and "you know what really grinds my gears?". I didn't intend for this to be a rant, but it does get a bit ranty in places. I've decided I'm ok with that :)
+
+  I've written this over the last week or so through a combination of Apple Notes on the fly, dictating at ChatGPT and Claude when a thought comes up and having it capture it, intentional writing and rethinking, and some final polish to try and organise it all together. I was pretty taken aback when I realised how long it had got. I contemplated breaking it up into separate pages, but that just seems gratuitous (though I did break out one point :D ). And besides, I think I'll come back to this over time and keep it up to date as well.
 </Callout>
 
 Most of what I know about doing business did not arrive as a single coherent philosophy.

--- a/src/content/posts/the-rules-i-try-to-do-business-by.mdx
+++ b/src/content/posts/the-rules-i-try-to-do-business-by.mdx
@@ -31,6 +31,16 @@ What follows is not a grand theory of management or a neat framework I sat down 
 
 ### Make it easy to do business with you
 
+I'm sure you have had a situation where you want to go and buy something from some online shop and something has gone wrong, something has broken. The checkout might not work correctly, or the whole order flow might be so completely different and novel that it throws you off, or maybe they're trying to upsell you repeatedly through the checkout process and you just give up.
+
+I actually had one a couple of weeks ago. I wanted to buy a drone flight controller, and the only vendor in this country who has this particular thing had an e-commerce site that wanted me to phone them to activate my account, to mitigate against spam orders, before I was allowed to place an order.
+
+So I'd go through the whole checkout process and then it got to the end, even said it had confirmed payment, and then said your order has been blocked for spam, please contact us on this phone number.
+
+Had I had any choice to buy from any other vendor, I probably would have done, but because they were the only vendor, I actually had to phone them.
+
+But talk about friction in your process and not making it easy to do business with you.
+
 Any friction is bad.
 
 That does not mean every service must be instant, free, or without controls. Some checks, approvals, and constraints exist for good reasons. **It means every piece of friction should have to justify its existence.**

--- a/src/content/posts/the-rules-i-try-to-do-business-by.mdx
+++ b/src/content/posts/the-rules-i-try-to-do-business-by.mdx
@@ -247,7 +247,7 @@ Each team meets its local target while the customer carries the accumulated weig
 
 The Cynefin framework is one of the most useful tools I have found for thinking about how to respond to different kinds of problems.
 
-Its value is not in giving every situation a clever label. **It is in recognising that different conditions require different methods.**
+Do not get too hung up on labelling everything. The useful bit is that it stops you treating every problem the same way.
 
 Some problems are clear enough that established practice, standardisation, and automation are appropriate. Some are complicated and require expertise and analysis.
 

--- a/src/content/posts/the-rules-i-try-to-do-business-by.mdx
+++ b/src/content/posts/the-rules-i-try-to-do-business-by.mdx
@@ -69,9 +69,7 @@ Customers should be able to describe the outcome they need. It is your job to wo
 
 Do you ever think about what it's like to use your services? No, really though, do you ever actually go and use your services yourself?
 
-Use your own tools, systems, and processes.
-
-No, really, force yourself. Get hands on with everything you provide. Experience it all. And wear the hat of the most picky customer ever.
+Force yourself. Get hands on with everything you provide. Experience it all. And wear the hat of the most picky customer ever.
 
 Do not simply watch a demonstration or ask somebody to guide you through the happy path. Try to achieve a real outcome in the same way a customer would.
 

--- a/src/content/posts/the-rules-i-try-to-do-business-by.mdx
+++ b/src/content/posts/the-rules-i-try-to-do-business-by.mdx
@@ -1,0 +1,771 @@
+---
+title: "The Rules I Try to Do Business By"
+description: "A collection of rules, habits, and bits of borrowed wisdom that have shaped how I try to build services, lead teams, and do business with people."
+date: 2026-08-01
+tags: ["leadership", "culture", "operations", "systems-thinking", "organisation-design", "automation", "work-life-balance"]
+toc: true
+---
+
+import Callout from '../../components/Callout.astro';
+
+<Callout variant="neutral" icon="😤">
+  I have realised while writing this that it's become a blend of "here's some things I've learned" and "you know what really grinds my gears?". I didn't intend for this to be a rant, but it does get a bit ranty in places. I've decided I'm ok with that :)
+</Callout>
+
+Most of what I know about doing business did not arrive as a single coherent philosophy.
+
+It came from people I worked for, people I worked alongside, things I read, mistakes I made, and stories that stayed with me long after I had forgotten where I first heard them. Some of it was learned working in businesses selling services to external customers, and some comes from running internal service provider teams in much larger businesses. All of it comes from businesses that operate profitably and in settings where I generally observe people enjoy coming to work.
+
+Over time, I realised that the distinction between those two worlds (internal vs external customers) is smaller than it first appears.
+
+Whether somebody is paying you directly or depending on your team from elsewhere in the same company, the job is fundamentally the same. Understand what they are trying to achieve. Make it easy for them. Do good work. Take responsibility when things go wrong. Do not make your complexity their problem.
+
+The language tends to change inside larger companies. Customers become users, requesters, stakeholders, or business units. I think that change in language can cause a real change in behaviour.
+
+A customer is somebody whose trust you need to earn and can lose. A user sounds like somebody who is expected to use whatever you have chosen to provide.
+
+I think they are customers, and customers can fire you. Internally, they just do it in less obvious ways.
+
+What follows is not a grand theory of management or a neat framework I sat down and invented. It is a collection of rules, habits, and bits of borrowed wisdom that have shaped how I try to build services, lead teams, and do business with people.
+
+## Make it easy to do business with you
+
+Any friction is bad.
+
+That does not mean every service must be instant, free, or without controls. Some checks, approvals, and constraints exist for good reasons. It means every piece of friction should have to justify its existence.
+
+Every form field, handoff, repeated question, and unnecessary delay places a small tax on the customer. The team responsible for a process will usually underestimate that tax because the time is being spent by somebody else.
+
+An additional five minutes does not seem significant when you are designing a form. When thousands of people encounter that five minutes repeatedly, it becomes a meaningful organisational cost.
+
+Friction also changes behaviour. People stop asking for help. They work around the official process, keep their own spreadsheets, or buy software on a company card. Small problems are left alone until they become serious ones because engaging with the service feels harder than living with the problem.
+
+A service can be technically correct and still be failing because it is too difficult to use.
+
+The customer should not need to understand your organisational structure, your queue architecture, or your internal vocabulary before they can ask for help. They should not need to know which of six teams owns their problem.
+
+Make the front door obvious. Make the request simple. Take responsibility for moving it through the machinery behind the scenes.
+
+Your complexity is not part of the product. A good service absorbs complexity rather than exporting it.
+
+This applies to external service providers, but it is just as important inside a company. A colleague asking for help should not need to understand the difference between the infrastructure team, the applications team, the service desk, the security function, and the automation group.
+
+Those distinctions may matter greatly to you. They probably do not matter at all to the person who needs something done.
+
+Customers should be able to describe the outcome they need. It is your job to work out what happens next.
+
+## Be the customer
+
+Use your own tools, systems, and processes.
+
+No, really, force yourself. Get hands on with everything you provide. Experience it all. And wear the hat of the most picky customer ever.
+
+Do not simply watch a demonstration or ask somebody to guide you through the happy path. Try to achieve a real outcome in the same way a customer would.
+
+Raise the request through the normal front door. Use the standard account. Follow the published instructions. Wait in the same queue. Read the automated messages and experience the handoffs.
+
+See whether you can tell what is happening, what you are expected to do next, and whether anybody has actually understood the thing you are trying to achieve.
+
+This is some of the cheapest and most valuable customer research you can do. It costs almost nothing and can reveal problems that have survived months of service reviews, reporting, and meetings.
+
+The problem is that senior and experienced people tend to become insulated from the ordinary experience.
+
+They have elevated access. They know which team owns the problem. They know the undocumented workaround. They can message somebody directly, walk across the office, or quietly fix the underlying record themselves.
+
+Every one of those privileges makes it easier for them to get something done and harder for them to understand what everybody else experiences.
+
+The shoulder tap is particularly dangerous. You encounter a problem, message somebody you know, and it is resolved immediately. From your perspective, the organisation appears responsive and effective.
+
+The ordinary customer does not know who to message. They submit a request, receive a generic acknowledgement, and wait. They may be passed between teams, asked for information the organisation already holds, or directed towards instructions that do not quite work.
+
+You and the customer may nominally be using the same service, but you are not having the same experience.
+
+The more senior you become, the more deliberately you need to remove that insulation. Use a normal account. Start with the public documentation. Resist the urge to intervene at the first sign of friction.
+
+Pay attention to the moment when you feel tempted to abandon the process and contact somebody directly. That temptation is evidence.
+
+Leaders should mystery shop their own organisations. Product teams should use their own products. Service owners should raise their own requests. Executives should attempt the processes they mandate for everyone else.
+
+You cannot improve an experience you have arranged never to receive.
+
+## You get exactly one chance to make a first impression
+
+Yeah yeah, I know, it's a cliché, but that's because it's true!
+
+The first interaction establishes the customer's mental model of everything that follows. It tells them whether you are attentive, competent, organised, and interested.
+
+A poor first impression creates a trust deficit that you may spend months correcting. A good one creates confidence and buys a certain amount of patience for the day when something inevitably goes wrong.
+
+This applies to the first sales conversation, the onboarding experience, the first screen of an application, and the first time an employee contacts an internal support team.
+
+Customers do not experience your strategy deck. They experience moments.
+
+Dom Monkhouse once told me a story from an acquisition due diligence exercise. He had gone to visit a small business and, immediately inside the front door, was a staircase leading up into the office.
+
+Sitting on the stairs were four copies of the Yellow Pages.
+
+(For anyone too young to remember them, the Yellow Pages was a huge printed business directory that arrived once a year. That frequency is important.)
+
+The first one had arrived and somebody had put it on the stairs. It remained there for an entire year, visible to every employee who walked past it each day.
+
+The next one arrived and somebody apparently thought, yes, that seems to be where we keep the Yellow Pages, so they placed it alongside the first.
+
+Then it happened again.
+
+And again.
+
+Four years of employees walking past the growing pile. Nobody threw them away. Nobody questioned why they were there. Nobody cared enough to spend ten seconds fixing it.
+
+It would be tempting to dismiss this as an isolated thing. However, as is often the case, it was more than that. It turned out this was the visible tip of the iceberg, so to speak, and revealed a mountain of organisational apathy.
+
+The due diligence went on to uncover a business riddled with problems that came from the same underlying behaviour. Processes had been neglected. Details had been ignored. Problems that everybody could see had become normal because nobody felt responsible for dealing with them.
+
+The Yellow Pages did not cause the problems, obviously. But they were a giant warning light drawing immediate attention to them. And not only that, every single visitor to the office was presented with that warning light in their first impression.
+
+They also revealed where the expectation bar had been set for everybody working in that company.
+
+Every person who walked past those directories received the same quiet message: this is acceptable here. Things can be left. Details do not matter. If everybody else has ignored it, you may ignore it too.
+
+Every business has its own version. The problem is that you stop seeing yours.
+
+Standards rarely collapse in one dramatic moment. They drift downwards through thousands of small permissions.
+
+One neglected thing makes the next neglected thing feel slightly more acceptable. Eventually the organisation becomes surrounded by problems that everybody can see but nobody experiences as unusual.
+
+The opposite is also true.
+
+Fixing the small thing tells the people around you that noticing is worthwhile. It gives them permission to care. When somebody corrects the broken link, improves the badly worded message, or removes four years of Yellow Pages from the staircase, they drag the expectation bar upwards.
+
+That can spread in exactly the same way as apathy. People notice what good looks like. They improve things without waiting to be told. Care becomes normal.
+
+This is not about performative tidiness or paralysing perfectionism. There is always a point at which polishing becomes waste. It is about recognising that visible standards shape behaviour.
+
+Give yourself permission to let small things matter. Let them pull the bar up instead of allowing neglect to drag it down.
+
+So go and look for your own Yellow Pages moments. Walk in through your own front door, sit in your own reception, read your own automated emails, and pay attention to whatever has become part of the furniture. The things you no longer notice are the things a visitor notices first.
+
+Then ask what they are telling people. What is your team learning about the standard you will accept, simply by watching what you walk past? What are you telling the world your tolerance allows?
+
+Where is your bar? Not the one written into your values or your strategy deck. The one your team can see from where they are sitting.
+
+Customers cannot see most of what happens inside a service provider. They cannot inspect your architecture, internal controls, project plan, or the quality of the discussions taking place behind the scenes.
+
+They make judgements from the evidence available to them, and that evidence often consists of tiny details.
+
+A spelling mistake in an important message, an unresolved template variable in an automated email, a broken link, an error message that blames the customer, or a form that asks the same question twice can each appear trivial.
+
+Together, they communicate care or carelessness.
+
+Customers reasonably assume that visible sloppiness may be evidence of invisible sloppiness.
+
+First impressions matter because the small things are often evidence of the big things. They also help determine how big those things eventually become.
+
+## Your customer can fire you
+
+For an external service provider, the idea that a customer can leave is obvious. Inside a company, it is easier to forget.
+
+An internal team can convince itself that it has a captive customer base. Employees are required to use the system. The process is policy. The platform is mandated and there is no visible competitor.
+
+Customers still have choices.
+
+They can minimise their engagement with you. They can buy around you, build around you, or hire people specifically to compensate for your weaknesses. They can create parallel processes, private spreadsheets, and shadow systems.
+
+They can escalate until responsibility is moved elsewhere. Senior leaders can reorganise the company around you.
+
+Sometimes being fired internally looks like losing a platform. Sometimes it looks like outsourcing. Sometimes your team continues to exist, but the rest of the organisation stops trusting it with anything important.
+
+This is why I prefer the word customer to user.
+
+User defines somebody by their interaction with a system. Customer keeps the focus on the outcome they are trying to achieve and the quality of the service they receive.
+
+The language changes the questions you ask. Are we solving the right problem? Was the experience good? Would they choose us again? Would they recommend us? Did we make them more successful?
+
+Those are healthier questions than asking whether a ticket technically met its service-level agreement.
+
+An SLA can tell you that the organisation responded within four hours. It cannot tell you whether the response was useful, whether the customer had to explain the problem three times, or whether the issue passed through four teams before reaching somebody who could help.
+
+So measure the experience as well as the process.
+
+Touchpoint measures such as transactional NPS are much better at this. You ask a question or two immediately after a real interaction, while the person still remembers what happened and can tell you which part of it was painful.
+
+The value is in the frequency and the volume. An annual relationship survey gives you a single, heavily averaged verdict, usually months after the events that formed it and usually from the people with the strongest feelings. A touchpoint measure gives you a continuous pulse, in enough volume to see the pattern by team, by service, by request type, and over time.
+
+It tells you that something changed in March rather than telling you next January that people are unhappy.
+
+The free-text comment is often worth more than the score. People will describe exactly where the journey hurt if you ask them while it is still fresh.
+
+Be careful what you do with it. The moment a score becomes a target, people start managing the score rather than the experience. Treat it as a prompt to go and look, not as a stick.
+
+Do not mistake compliance with your process for success in the eyes of the customer.
+
+## Do not make your problems the customer's problems
+
+This is one of the most common failures in service design.
+
+The organisation has fragmented systems, so the customer is asked for the same information repeatedly. A team has poor visibility, so the customer is asked to confirm something the company already knows.
+
+Ownership is unclear, so the customer is passed from one department to another. A system cannot perform an action, so the customer is given a cumbersome set of manual instructions.
+
+None of those things is the customer's fault.
+
+Asking an employee to confirm their employee number, manager, department, device type, and office location may sound harmless. If all that information already exists inside your systems, you are asking the customer to compensate for your inability to retrieve it.
+
+The phrase "our process requires" should always make us suspicious. Sometimes the requirement is legitimate. Quite often, it is simply an old decision nobody has challenged.
+
+Good service providers do the joining up. They reconcile the systems, find the correct owner, and carry context between teams.
+
+That work can be difficult and expensive. It is also part of the value being provided.
+
+Customers should not have to perform unpaid systems integration on your behalf.
+
+This is also why user experience matters far beyond the appearance of software. User experience is the complete experience of attempting to achieve something through your service.
+
+It includes the forms, support processes, meetings, invoices, contracts, instructions, and automated messages.
+
+Where does the customer begin? Do they understand what is being asked? Does the service behave as they expect? What happens when they make a mistake? Can they tell whether something worked, and do they know what will happen next?
+
+Most bad experiences were not deliberately designed to be bad. They emerged because each team built its own part, optimised its own step, and assumed somebody else was responsible for the journey as a whole.
+
+Someone must own the experience across the boundaries.
+
+Some people have a natural instinct for user experience and others do not. That is fine, provided they know it.
+
+If you are not good at it, partner with somebody who is and give them permission to challenge you. Involve them before the process has hardened and the system has been built.
+
+Do not bring them in at the end to apply a coat of UX paint.
+
+## Work hard and be nice to people
+
+Years ago, Rob came back from a shop in Shoreditch with a poster that said, "Work hard and be nice to people."
+
+It is difficult to improve on that as a philosophy for doing business.
+
+Working hard while treating people badly creates a culture of ego, fear, and burnout. Being nice without doing the work creates a pleasant but ineffective organisation.
+
+You need both.
+
+Being nice does not mean avoiding difficult conversations, tolerating poor performance, or agreeing to every request. It means treating people with respect. It means being direct without being cruel and remembering that the person at the other end of a difficult situation is still a person.
+
+Customers notice how you behave when things go wrong.
+
+Anybody can be friendly when the service is working and the account is profitable. Character becomes visible during incidents, disagreements, missed expectations, and commercial tension.
+
+Take responsibility. Tell the truth. Do not become defensive. Focus on what needs to happen next.
+
+Competence and kindness are not competing virtues.
+
+The same respect should extend to the different functions inside a business.
+
+Very early in my career at Bluhalo, Vimal Patel became something of a mentor to me. He once challenged a view that was fairly common among those of us back in the office.
+
+We saw the sales team attending dinners, networking events, and conferences. They travelled frequently and appeared to be enjoying an endless succession of drinks and meals on expenses. Meanwhile, we believed we were the people doing the real work.
+
+Vimal's point was that it was probably not much fun at all.
+
+Imagine going out several nights a week, constantly travelling, and repeatedly walking into rooms full of strangers. You have to begin conversations, make people like and trust you, remember names, absorb rejection, and remain energetic when you are tired.
+
+All the while, you are carrying the pressure of working out where the next piece of revenue will come from.
+
+In many businesses, the sales team is effectively trying to find the money that will fund everybody's next pay cheque.
+
+The pipeline never stops moving. Deals slip, budgets disappear, competitors appear, and last month's success does not remove the need to sell again this month.
+
+Respect your sales team. They bring in the calories that keep the company going.
+
+That does not put them beyond criticism. Bad sales behaviour can create enormous problems for customers and delivery teams. Overpromising or selling work that cannot be delivered destroys trust.
+
+The respect has to work both ways. Sales must respect the people who fulfil the promises, and delivery must respect the people who create the opportunity to make those promises.
+
+Acquiring, serving, and retaining a customer are not separate activities. They are parts of the same system.
+
+## Think in systems
+
+Most business problems are not isolated events. They are products of a system.
+
+A missed target may be an individual performance problem. It may also be the predictable result of incentives, workload, unclear ownership, poor information, or a process that rewards the wrong behaviour.
+
+Fixing the person without fixing the system often means the same problem returns with a different person attached to it.
+
+Thinking in systems means looking beyond the immediate symptom. Ask what conditions produced the outcome, what behaviour the system encourages, and where information stops flowing.
+
+Look for where one part has been optimised at the expense of the whole. Think about what unintended behaviour your proposed solution might create.
+
+This matters particularly inside large organisations. Individual teams frequently make perfectly rational decisions that combine to create an irrational customer experience.
+
+Every department protects its own capacity with another approval. Every function creates its own intake form. Every system demands its own copy of the data.
+
+Each team meets its local target while the customer carries the accumulated weight of all that local optimisation.
+
+The Cynefin framework is one of the most useful tools I have found for thinking about how to respond to different kinds of problems.
+
+Its value is not in giving every situation a clever label. It is in recognising that different conditions require different methods.
+
+Some problems are clear enough that established practice, standardisation, and automation are appropriate. Some are complicated and require expertise and analysis.
+
+Some are complex, with cause and effect becoming clear only in retrospect, so progress depends on experiments, feedback, and adaptation. Some situations are chaotic and require immediate action to create enough stability for proper understanding to begin.
+
+A common management failure is to use the same approach everywhere.
+
+We apply rigid processes to complex problems. We experiment where good practice is already well established. We commission lengthy analysis during a crisis that requires immediate action.
+
+Understanding the kind of problem you are facing should come before choosing the method for solving it.
+
+Systems thinking also requires humility. A result that looks irrational from where you are standing may make perfect sense once you understand the wider system that produced it.
+
+## Understand the load-bearing walls
+
+Imagine somebody buying an old house and deciding to open up the ground floor.
+
+There is a wall in the middle of a room that seems inconvenient. Nobody can explain why it is there and there is no obvious reason not to remove it.
+
+The new owner knocks it down and discovers, rather late in the process, that it was holding up everything above it.
+
+Businesses contain load-bearing walls too.
+
+They are the odd approval, the strangely divided responsibility, the manual check, the team boundary, or the architectural decision that no longer seems to make sense.
+
+Somebody new takes ownership, sees an apparently irrational arrangement, and quite reasonably decides to simplify it.
+
+Sometimes they are right. The arrangement may be outdated, badly conceived, or the result of a lazy decision made years ago.
+
+It may also be an intentional compromise that is carrying a load nobody has noticed.
+
+Chesterton's fence is another way of expressing the same idea. You encounter a fence across a field and cannot see why anybody put it there.
+
+Your lack of understanding is not, by itself, a reason to remove it. It is a reason to study the fence until you understand what problem it was intended to solve.
+
+Once you understand the purpose, you can decide whether that purpose still matters and whether the fence remains the right answer.
+
+When teams change or responsibilities pass between people, do not begin from the assumption that those who came before you were clueless.
+
+Respect the possibility that they were responding to information, constraints, and trade-offs that are no longer visible.
+
+Study why the decision was made. Look for the documentation, speak to the people who were there, and examine what was happening at the time.
+
+If you cannot find the explanation, study harder and try to reconstruct it.
+
+The absence of documentation is not proof that there was no reasoning.
+
+This does not mean preserving every inherited process through misplaced reverence. Organisations accumulate plenty of nonsense.
+
+It means understanding something before changing it, particularly where the consequences might travel further than the change itself.
+
+A decision that appears inefficient may have been protecting reliability. A duplicated responsibility may have been compensating for a control weakness. A manual step may exist because an automated one previously caused damage.
+
+The original answer may no longer be correct, but the question it was answering may still exist.
+
+The best defence is to preserve the reasoning behind decisions while the people who made them can still remember it.
+
+One useful method is the [Y-Statement](https://socadk.github.io/design-practice-repository/artifact-templates/DPR-ArchitecturalDecisionRecordYForm.html). The structure is roughly this: in the context of a particular situation, facing a particular concern, we decided to take one course of action rather than the alternatives, to achieve a desired outcome, while accepting a stated downside.
+
+The final part matters. Real decisions usually involve a trade-off.
+
+Recording only what was chosen makes the decision appear more obvious and absolute than it really was. Recording what you knowingly accepted helps the next person understand the circumstances under which the decision might need to change.
+
+Write down why, not just what.
+
+Assume that somebody else will eventually inherit your house. Label the load-bearing walls before they arrive with a sledgehammer.
+
+## Work in the open
+
+One of the worst patterns I see in modern organisations is important work and decision-making disappearing into private Slack channels and direct messages.
+
+If you use Slack, favour public channels. Celebrate having a high ratio of public channels to private ones, and an even higher ratio of channel conversations to direct messages.
+
+Work conducted in private is work the organisation is likely to lose.
+
+The immediate participants may remember the conversation, but everybody else sees only the eventual outcome. The context, alternatives, disagreement, and reasoning disappear.
+
+Months later, somebody encounters the result and cannot understand why it exists. We have created another unexplained fence and another apparently pointless wall.
+
+There are legitimate reasons for working privately. Personal matters, commercially sensitive discussions, security incidents, and genuinely confidential subjects need appropriate protection.
+
+Privacy should be a deliberate control applied for a reason. It should not be the default setting for ordinary work.
+
+My friend and former colleague Jesse Taylor once captured the question brilliantly: "What are they afraid of?"
+
+It is worth asking whenever a team habitually works behind closed doors.
+
+What specifically would go wrong if colleagues could see this discussion?
+
+Sometimes there is a good answer. Often there is only habit, hierarchy, or discomfort with allowing unfinished thinking to be visible.
+
+Working in the open does not mean every employee must read everything. It means the work is available to the people who need it, including people you have not yet met.
+
+Assume you will eventually leave the business. Assume somebody new will inherit the service, system, or decision you are working on.
+
+Assume they will need to search for your reasoning without knowing your name, the date of the conversation, or which private group contained it.
+
+Could they find it? Could they understand how you reached the decision, or would they find only the final artefact and be left to guess?
+
+Closed channels and direct messages create a similar problem to the person who never takes time off. Knowledge remains concentrated around particular individuals.
+
+The organisation appears to function while they are present, but struggles to reproduce their understanding without them.
+
+This can happen innocently. Direct messages feel fast. Private groups feel safe. A small number of familiar people can reach decisions quickly without explaining all the context to everybody else.
+
+The price is paid later through repeated conversations, duplicated work, and decisions that have to be rediscovered.
+
+Work in the open. Put decisions somewhere durable and searchable. Summarise what was agreed and capture why.
+
+Link the conversation to the resulting work and the resulting work back to the decision.
+
+Organisational memory does not happen automatically. You have to design for it.
+
+## Never rescue a process silently
+
+One of the most dangerous things a capable team can do is quietly prevent a broken system from ever appearing broken.
+
+People fill in missing information, chase approvals, manually route work, and remember all the unwritten exceptions. They correct malformed requests and reconcile conflicting records without making any fuss.
+
+The customer sees a service that just about works. Management sees acceptable performance. The people holding it together see the truth, but they are too busy compensating for the problems to fix them.
+
+I am not suggesting you stop rescuing the customer. Everything else in this article argues that you should, and a service that deliberately lets somebody down to prove an internal point has just invented a new way of making its problems their problems.
+
+The difficulty is that the rescue usually appears to cost nothing and leaves no trace. Somebody spots the malformed request, knows from experience which team it actually belongs to, forwards it, and gets on with their day. The customer is served, the report looks fine, and the thing that caused it is exactly as broken tomorrow morning.
+
+So do the rescue, and then make it expensive to ignore. Record what happened. Note what the person had to know and what they had to do, because that is a fairly precise specification for whatever should have handled it instead. Count how often it happens and put that number alongside the others you review each week.
+
+Work with a number attached to it gets prioritised. Work that lives in somebody's head and costs them ten minutes a day does not, because those ten minutes belong to them rather than to the business.
+
+Heroics are useful during an incident. They are a terrible operating model.
+
+If you want to understand how much of your service depends on people covering for it, you can go looking on purpose, at a time you choose rather than one a customer chooses for you. Send a badly formed request through and see where it ends up. Ask the person who always knows to stay out of it for a fortnight.
+
+Holidays do this for nothing. Very little reveals an undocumented process quite like the person who holds it being genuinely unavailable, which is one of the reasons I care so much about people taking their leave.
+
+The aim is not to eliminate human involvement. It is to stop spending human judgement on work that only requires human memory, persistence, or pattern matching.
+
+## Do not become over-leveraged
+
+There is a reflex in some teams that treats technical debt as inherently shameful, as though any of it existing at all is evidence that somebody did their job badly.
+
+I do not think that is right. It is far more useful to think about technical debt the way you think about financial debt.
+
+Debt is a tool. It is a large part of what drives an economy and, used sensibly, it is what allows a business to do something this year rather than in three years' time. Taking some on is usually evidence of a deliberate choice about speed, not evidence of carelessness.
+
+What people forget is what happens after the decision. When you create something, you own it. It has to be maintained, patched, understood, documented, explained to whoever arrives next, and eventually replaced.
+
+Nothing you build exists for free, and the bill does not arrive on the day you build it. It arrives every month afterwards, for as long as the thing survives.
+
+There is nothing wrong with having a mortgage on your house. What is not fine is having a mortgage you cannot afford.
+
+An over-leveraged technical team behaves much like an over-leveraged household. The weight starts to show, and it tends to show in one of two ways.
+
+Either the team can no longer move at a sensible pace, because every change has to be threaded carefully through things nobody wants to touch, or the quality of the work starts to slip because there is no room left to do it properly.
+
+It also compounds. The more you are carrying, the more separate things demand attention, and the more your people spend their days switching between them rather than finishing any of them. Context switching is a tax you pay on top of the interest.
+
+Refusing to make these decisions does not simply slow the work down, it chokes the creativity out of a team.
+
+Nobody offers up the interesting idea when they already know there is no room to build it, and watching your week disappear into servicing decisions somebody else avoided making is thoroughly demoralising. That is a more expensive loss than the debt itself, and a much harder one to reverse.
+
+So be selective about what you take on, and be equally intentional about what you are prepared to remove. Most organisations are considerably better at adding than they are at subtracting.
+
+Have one CRM, not three. Pick Microsoft or Google, not both. Teams or Zoom for your meetings, not both. Normalise where you can and actually make the call, because the alternative is quietly agreeing to feed all of it forever.
+
+The Y-Statement from earlier does the same job here. A decision recorded properly, including the downside you knowingly accepted, is a decision you can still defend a year later when somebody asks why you did not do the other thing.
+
+A good decision-making process does not only make you comfortable committing to something. It makes you comfortable deciding, deliberately and on the record, not to do something else.
+
+## Don't stumble the wrong side of a moat
+
+There is a pattern worth recognising in the way software vendors grow inside your business.
+
+They arrive with one thing that is genuinely good, and that thing is usually displaceable. You could swap it out next year if you decided to. Then they add the features that make leaving difficult, and those features are rarely the ones you originally bought.
+
+Come for the X, stay for the Y.
+
+Some examples that are top of mind for me at the moment. Anthropic: come for the model, stay for the routines and Claude Design. Workboard: come for the OKRs, stay for the 1:1s. Miro: come for the multiplayer whiteboard, stay for the prototypes and wireframes. Slack: come for the chat, stay for the enormous ChatOps ecosystem and the growing pile of AI features.
+
+To be clear, I have no objection to tools that do lots of things. Those are all good products, and breadth is frequently exactly what you want.
+
+What I dislike is the tool you allow through the door for one purpose, which then creeps unintentionally into an increasing number of corners of your business. Nobody sits down and decides to do this. It happens one sensible convenience at a time.
+
+Every one of those small conveniences makes the relationship a little stickier. That is fine while the tool is the best available answer.
+
+It becomes a problem when the tool grows, as tools do, and the part you depend on starts to lag behind. By that point you are no longer making a decision about one product. You are making a decision about nine things you had not really noticed you were buying.
+
+It also quietly distorts how you assess everything else. You glance at something new and think, well, our existing tool does that, so we do not need it. Sometimes that is true. But you should be free to consider all of your options, and "we already own something that technically does this" is not the same statement as "we already own something that does this well".
+
+I think of those all-in-one televisions you used to be able to buy. A television with a built-in DVD player, a VHS player, and a little clock on the front. One device that does everything! Badly. With the most confusing remote control you have ever held.
+
+A specific tool that does one thing will almost always do that one thing better. That does not mean you should go and buy forty of them, only that "it is already included" is weak evidence on its own.
+
+All of this is far easier to describe than to do. Vendors work extremely hard at stickiness because it is their business model, and the worst thing that can happen to a SaaS company is account reduction. The packaging, the pricing, and the roadmap are all designed to make removing anything feel unreasonable.
+
+So stay on top of it. Look at your ecosystem as a whole rather than one renewal at a time, and make the calls intentionally. Sometimes consolidating is exactly right and you should do it enthusiastically. Sometimes it is not, and the specialist tool has earned its place on the invoice.
+
+The point is to decide, rather than to arrive somewhere by accumulation.
+
+## Use automation as a design constraint
+
+There is familiar advice that you should never automate a broken process. It is directionally sensible, but too easily repeated.
+
+Attempting to automate a process is often how you discover that it is broken.
+
+Automation is intolerant of ambiguity.
+
+A person can look at an incomplete request and infer what the customer probably meant. They can remember that requests from a particular department normally go to one person unless they involve finance, in which case they go somewhere else, except at quarter end.
+
+Software cannot operate on folklore.
+
+To automate a process, you have to define the inputs, ownership, decisions, exceptions, and desired outcome. You have to confront the places where the organisation depends on context that exists only in somebody's head.
+
+Automation can therefore be a forcing function for better process and systems design.
+
+The objective is not to reproduce every existing step in software. It is to question the steps.
+
+Do we need this approval? Why are we asking for information we already have? Why does the work pass through three queues? Why does a person have to decide which team receives it?
+
+Bad automation makes a poor process move faster. Good automation forces you to define a better process.
+
+This principle matters even where you do not ultimately automate everything. The attempt forces clarity. It makes the team agree on ownership, inputs, and outcomes.
+
+It reveals exceptions that have quietly become the normal way of operating.
+
+Where the process cannot be clearly described, it is unlikely to be consistently performed.
+
+## Make human routing optional
+
+A person whose job is to read incoming work and decide where to send it is often compensating for a service that has not been designed properly.
+
+That role may be necessary as a temporary safety net. It should not be a permanent architectural requirement.
+
+Human routers become bottlenecks. They introduce delay, inconsistency, and dependency.
+
+When they are experienced, they can make the process look remarkably effective because they know who really owns something and which wording indicates the underlying problem.
+
+That knowledge is valuable. It should be captured rather than permanently rented from one person's memory.
+
+Design the service so that work can identify its own destination wherever reasonably possible. Use structured information, known customer context, service ownership, classification rules, and automation.
+
+Where certainty is not possible, use a confidence threshold and send the genuinely ambiguous cases to a person.
+
+Human routing should be the exception path, not the happy path.
+
+This matters even more as AI becomes part of service delivery. AI can help interpret messy language, enrich requests, and recommend destinations, but it should not become a more expensive disguise for an undefined ownership model.
+
+The system still needs to know who is responsible for what.
+
+People are most valuable when they are exercising judgement, showing empathy, resolving genuine ambiguity, and making decisions that carry consequences.
+
+Reading a form and forwarding it to another queue is not meaningful human involvement.
+
+Build systems that can move work by themselves. Keep people available for the moments that deserve them.
+
+## Use a meeting structure that works
+
+Most meetings are bad because they have not really been designed.
+
+They mix status reporting, problem-solving, announcements, and decisions into an unstructured conversation.
+
+The first topic consumes half the available time, the most important issue is raised with five minutes remaining, and everybody leaves with a slightly different understanding of what was agreed.
+
+Use the EOS Level 10 Meeting structure.
+
+I have used it for around fifteen years and genuinely believe it can change the working culture of a team.
+
+It is normally presented as a leadership meeting, but the underlying structure works far more broadly. I have used it with operational teams, functional leadership groups, and people coming together around a shared body of work.
+
+The meeting follows the same rhythm each time. It begins by allowing people to arrive properly, then reviews the numbers, priorities, relevant people, customer headlines, and the previous actions.
+
+Most of the meeting is protected for identifying, discussing, and actually solving the most important issues. It finishes by confirming actions, agreeing what needs to be communicated, and rating the quality of the meeting itself.
+
+The official [Level 10 Meeting structure is explained here](https://www.eosworldwide.com/level-10-meeting).
+
+The power comes from discipline rather than novelty.
+
+The meeting happens at the same time, follows the same structure, and ends on time. Status updates do not consume the space intended for solving problems.
+
+Issues are captured rather than allowed to derail the meeting, then prioritised so that the team works on what matters most rather than simply starting at the top of a list.
+
+Run properly, it creates a dependable operating rhythm. Problems have somewhere to go. Actions have owners. Numbers are reviewed consistently and unresolved issues cannot hide indefinitely inside vague conversation.
+
+One of the disciplines I value is the expectation that people are fully present.
+
+In an in-person meeting, that meant putting away technology. That principle is harder in a remote world, where the laptop is also the meeting room.
+
+I try to recreate the spirit of it by running the meeting through a shared Miro board or something similar. Everybody is looking at and contributing to the same workspace rather than disappearing into private notes, email, or Slack while the meeting happens around them.
+
+The structure only works when you respect it. If every issue is discussed the moment it appears, if actions remain permanently incomplete, or if the meeting routinely overruns, it gradually becomes an ordinary meeting with some EOS terminology attached.
+
+I have introduced a lot of people to properly run Level 10 meetings over the years. Almost every time, somebody remarks that it is one of the best meetings they have ever attended.
+
+Most recently, that was Mark Michelman and Matthew Davenport, when I began working with them on my team about a year ago.
+
+That reaction says less about the brilliance of one meeting format than it does about the very low standard people have learned to expect from meetings.
+
+Give meetings a purpose, a rhythm, and a method for reaching decisions. Respect everybody's time enough to design the meeting rather than merely scheduling it.
+
+## Take time off, and do it properly
+
+Take your holiday.
+
+Spread it throughout the year, book it well in advance where you can and, when the time comes, actually take it. This is especially important if you have a family.
+
+It is very easy to let work consume the calendar. There is always a significant customer opportunity, a difficult project, a quarter end, a budget cycle, or some problem that apparently cannot survive your absence.
+
+Leave enough empty space in the diary and work will happily fill all of it.
+
+For a long time, I allowed that to happen.
+
+I immersed myself in work and treated the demands of the business as though they naturally deserved first call on my time. There was always a good justification.
+
+I was building something, solving something, or carrying responsibility for something that mattered. None of those reasons was invented, but together they allowed work to occupy far more of my life than I realised at the time.
+
+COVID rotated my priorities.
+
+Like many people, I was forced to stop and look differently at how I had been spending my time. I realised that I had missed a meaningful chunk of my children's lives by being so immersed in work.
+
+That is not time you can recover later.
+
+Children do not pause while you finish an important period in your career. They do not stay the same age while you get through a difficult quarter, complete an acquisition, or wait for the business to become less demanding.
+
+The years pass whether you make room for them or not.
+
+My balance is different now. I deliberately prioritise securing quality time with my family.
+
+That does not mean work no longer matters, or that I have found some perfect separation between the two. It means family time goes into the plan as something important in its own right, rather than being left to compete for whatever remains after work has taken what it wants.
+
+I currently work for a US-based company, so I accept that I will occasionally need to do things in somebody else's timezone. A global business requires some give and take, and expecting every conversation to fit neatly inside UK working hours would not be reasonable.
+
+My counterbalance is to put hard boundaries around the parts of the week that matter most.
+
+On every UK working day, I have a hard-locked two-hour window between the end of school and the children going to bed. That is not an empty space in my calendar waiting for somebody to claim it. It is already committed.
+
+I reserve one evening a week, Monday, for meetings that need to happen in US hours. Because I know Monday may run late, I allow myself to start later and spend time with Rachel instead.
+
+The point is not to pretend the evening work has no cost. It is to acknowledge the cost and deliberately restore some balance elsewhere.
+
+From Tuesday to Thursday I work from the office. On Friday I work from home and keep to UK hours.
+
+None of this is perfectly symmetrical. Balance rarely is.
+
+It is a deliberate arrangement that allows me to meet the responsibilities of a global role without making my family absorb an undefined and potentially unlimited amount of disruption.
+
+The important thing is that the boundaries are designed in advance. They are not renegotiated every time a meeting invitation arrives.
+
+Book time away early. Put it in the calendar before everything else claims the space. Spread it through the year rather than relying on one large holiday to repair eleven months of exhaustion.
+
+The same principle applies at the level of an ordinary week. Protect the time that matters before work discovers it is available.
+
+When you are away, be away. Prepare a proper handover, make decisions in advance, and give other people the authority they need.
+
+Avoid spending the holiday physically beside your family while mentally remaining at work.
+
+Your family experiences your relationship with work even though they have no involvement in the business. They experience the cancelled plans, the half-present parent, the laptop at the dinner table, and the holiday spent checking messages beside the pool.
+
+If the organisation genuinely cannot function for a week without you, that is not simply evidence of your importance. It is evidence that you have built a fragile system.
+
+Taking leave exposes unclear ownership, missing documentation, and decisions that have been unnecessarily centralised. That can be uncomfortable, but it is useful information.
+
+The answer is to improve the system, not to avoid taking another holiday.
+
+There will be genuine exceptions. Sometimes a crisis happens at exactly the wrong time and responsible people step back in. The problem begins when everything is treated as an exception.
+
+Do not confuse permanent availability with commitment.
+
+A rested person makes better decisions, treats people better, and is less likely to turn every problem into a crisis. A leader who takes leave properly gives everybody else permission to do the same.
+
+Work matters. So does the life the work is meant to support.
+
+## A note on working from home
+
+My own balance includes working from home on Monday and Friday, while spending Tuesday to Thursday in the office with my team. That arrangement is deliberate. I value the flexibility of working from home, but I have also become increasingly convinced that it carries a real cost to learning, relationships, and the development of teams.
+
+**A note from me:** This section originally became a much longer part of this article. The more I wrote, the more obvious it became that it did not quite belong here. I also realised that I felt far too strongly about it to reduce it to a few comfortable paragraphs.
+
+So I have broken it out into a separate article and expanded on it properly: [Working from home holds your learning back](/writing/working-from-home-holds-your-learning-back/).
+
+The central argument is that productivity is not the same thing as development. A person can be highly productive at home while learning less, building fewer relationships, and receiving a much narrower view of how a business actually operates.
+
+I think this is particularly dangerous for younger workers. Many established professionals entered remote working with years of context, confidence, and relationships already behind them. We cannot take somebody directly out of education, place them alone at home, connect them to a sequence of scheduled calls, and reasonably expect them to develop the same breadth of commercial understanding.
+
+One of my favourite parts of running businesses and teams is helping people discover interests and build careers around them. Some of the conversations that change a person's direction begin with nothing more substantial than leaning across a desk and asking a question. We cannot possibly nurture people as effectively when every conversation first has to earn a place in somebody's calendar.
+
+I still believe in flexibility, and I use it myself. I simply no longer believe that full-time home working is an equivalent substitute for spending a meaningful part of the week together.
+
+## Scrutinise people who never leave
+
+People who refuse to take holiday are often praised for their dedication.
+
+Be careful.
+
+My accounting lecturer at college, whose name I wish I could remember and think may have been Neil, once told us a story from his time working in audit.
+
+There was a groundskeeper at a cemetery who had not taken meaningful time off in years.
+
+He was dependable, knew how everything operated, and was always there to make sure things ran correctly.
+
+Then he was hospitalised after an accident.
+
+Somebody else had to cover his work and discovered that he had been keeping two sets of books. He had been skimming money from the organisation and moving it into his personal savings.
+
+His refusal to take leave had not been extraordinary commitment. It had been part of the control system protecting the fraud.
+
+While he was present, he could maintain both versions of reality. His unexpected absence broke the system and allowed somebody else to see what had been happening.
+
+This is an extreme and deliberately nefarious example. Most people who refuse to take time off are not committing fraud.
+
+The underlying organisational risk is still real.
+
+Sometimes people make themselves indispensable because they cannot, or will not, build a machine that operates beyond them.
+
+They hold processes in their heads, become the only person with access to a system, and personally intervene whenever something goes wrong.
+
+They answer every question, approve every decision, and quietly compensate for weaknesses in the operation.
+
+This can happen without any bad intent.
+
+In fact, it is often the most conscientious and productive people who create the greatest hidden risk. They care deeply, work incredibly hard, and solve problems before anybody else knows those problems exist.
+
+Their productivity shields the fragility beneath them.
+
+At a glance, they appear to be your top performers. The work gets done, customers are happy, and problems disappear. The person appears irreplaceable.
+
+Look more closely at what happens when they take a fortnight off.
+
+Can somebody else perform the work? Are the processes documented? Do others have the necessary access and authority?
+
+Are they building capability around themselves or accumulating dependency?
+
+Consider what happens if they resign tomorrow. More uncomfortably, consider what happens if you need them to leave.
+
+Call it the bus problem, a single point of failure, or a bottleneck. The metaphor does not matter. The risk does.
+
+A genuinely great performer does not merely produce an exceptional volume of work.
+
+They make the people and systems around them more capable. They document what they know, distribute authority, train successors, and reduce the organisation's dependence on their continued presence.
+
+Their absence may be felt, but it should not cause the machinery to stop.
+
+Mandatory leave, proper handovers, and sensible job rotation are not signs that you distrust people. They are healthy controls.
+
+They expose undocumented work, weak segregation of duties, and responsibilities that have become dangerously concentrated in one person.
+
+Encourage people to take leave. Scrutinise those who consistently refuse.
+
+Not because they must be doing something wrong, but because the organisation may have become dependent on something only they can see.
+
+## Service is what the customer experiences
+
+The common thread through all of this is that service is not defined by the organisation chart, the process diagram, the platform you deployed, or the service level you reported.
+
+Service is what the customer experiences while trying to get something done.
+
+It is whether you made the journey easy and respected their time. It is whether you took ownership rather than exporting your complexity.
+
+It is whether the visible details inspired confidence and whether you were competent and decent when something went wrong.
+
+It is also whether you built a system that learns, or one that depends on good people repeatedly saving it.
+
+Whether you are selling a service to the outside world or providing one to colleagues inside a larger organisation, those are the things that determine whether people trust you.
+
+Trust takes time to earn, can be lost surprisingly quickly, and is one of the most valuable things a service provider can possess.
+
+This is not a finished collection of rules. I doubt it ever will be.
+
+Experience has a habit of adding new ones and occasionally forcing you to reconsider the old ones.
+
+That is probably how it should be.

--- a/src/content/posts/the-rules-i-try-to-do-business-by.mdx
+++ b/src/content/posts/the-rules-i-try-to-do-business-by.mdx
@@ -33,7 +33,7 @@ What follows is not a grand theory of management or a neat framework I sat down 
 
 Any friction is bad.
 
-That does not mean every service must be instant, free, or without controls. Some checks, approvals, and constraints exist for good reasons. It means every piece of friction should have to justify its existence.
+That does not mean every service must be instant, free, or without controls. Some checks, approvals, and constraints exist for good reasons. **It means every piece of friction should have to justify its existence.**
 
 Every form field, handoff, repeated question, and unnecessary delay places a small tax on the customer. The team responsible for a process will usually underestimate that tax because the time is being spent by somebody else.
 
@@ -47,7 +47,7 @@ The customer should not need to understand your organisational structure, your q
 
 Make the front door obvious. Make the request simple. Take responsibility for moving it through the machinery behind the scenes.
 
-Your complexity is not part of the product. A good service absorbs complexity rather than exporting it.
+Your complexity is not part of the product. **A good service absorbs complexity rather than exporting it.**
 
 This applies to external service providers, but it is just as important inside a company. A colleague asking for help should not need to understand the difference between the infrastructure team, the applications team, the service desk, the security function, and the automation group.
 
@@ -67,7 +67,7 @@ Raise the request through the normal front door. Use the standard account. Follo
 
 See whether you can tell what is happening, what you are expected to do next, and whether anybody has actually understood the thing you are trying to achieve.
 
-This is some of the cheapest and most valuable customer research you can do. It costs almost nothing and can reveal problems that have survived months of service reviews, reporting, and meetings.
+**This is some of the cheapest and most valuable customer research you can do.** It costs almost nothing and can reveal problems that have survived months of service reviews, reporting, and meetings.
 
 The problem is that senior and experienced people tend to become insulated from the ordinary experience.
 
@@ -77,7 +77,7 @@ Every one of those privileges makes it easier for them to get something done and
 
 The shoulder tap is particularly dangerous. You encounter a problem, message somebody you know, and it is resolved immediately. From your perspective, the organisation appears responsive and effective.
 
-The ordinary customer does not know who to message. They submit a request, receive a generic acknowledgement, and wait. They may be passed between teams, asked for information the organisation already holds, or directed towards instructions that do not quite work. You and the customer may nominally be using the same service, but you are not having the same experience.
+The ordinary customer does not know who to message. They submit a request, receive a generic acknowledgement, and wait. They may be passed between teams, asked for information the organisation already holds, or directed towards instructions that do not quite work. **You and the customer may nominally be using the same service, but you are not having the same experience.**
 
 The more senior you become, the more deliberately you need to remove that insulation. Use a normal account. Start with the public documentation. Resist the urge to intervene at the first sign of friction.
 
@@ -131,13 +131,13 @@ This is not about performative tidiness or paralysing perfectionism. There is al
 
 Give yourself permission to let small things matter. Let them pull the bar up instead of allowing neglect to drag it down.
 
-So go and look for your own Yellow Pages moments. Walk in through your own front door, sit in your own reception, read your own automated emails, and pay attention to whatever has become part of the furniture. The things you no longer notice are the things a visitor notices first.
+So go and look for your own Yellow Pages moments. Walk in through your own front door, sit in your own reception, read your own automated emails, and pay attention to whatever has become part of the furniture. **The things you no longer notice are the things a visitor notices first.**
 
 Then ask what they are telling people. What is your team learning about the standard you will accept, simply by watching what you walk past? What are you telling the world your tolerance allows?
 
 Where is your bar? Not the one written into your values or your strategy deck. The one your team can see from where they are sitting.
 
-The first interaction establishes the customer's mental model of everything that follows. It tells them whether you are attentive, competent, organised, and interested.
+**The first interaction establishes the customer's mental model of everything that follows.** It tells them whether you are attentive, competent, organised, and interested.
 
 A poor first impression creates a trust deficit that you may spend months correcting. A good one creates confidence and buys a certain amount of patience for the day when something inevitably goes wrong. This applies to the first sales conversation, the onboarding experience, the first screen of an application, and the first time an employee contacts an internal support team.
 
@@ -165,13 +165,13 @@ They can minimise their engagement with you. They can buy around you, build arou
 
 They can escalate until responsibility is moved elsewhere. Senior leaders can reorganise the company around you.
 
-Sometimes being fired internally looks like losing a platform. Sometimes it looks like outsourcing. Sometimes your team continues to exist, but the rest of the organisation stops trusting it with anything important. This is why I prefer the word customer to user.
+Sometimes being fired internally looks like losing a platform. Sometimes it looks like outsourcing. **Sometimes your team continues to exist, but the rest of the organisation stops trusting it with anything important.** This is why I prefer the word customer to user.
 
 User defines somebody by their interaction with a system. Customer keeps the focus on the outcome they are trying to achieve and the quality of the service they receive.
 
 The language changes the questions you ask. Are we solving the right problem? Was the experience good? Would they choose us again? Would they recommend us? Did we make them more successful? Those are healthier questions than asking whether a ticket technically met its service-level agreement.
 
-An SLA can tell you that the organisation responded within four hours. It cannot tell you whether the response was useful, whether the customer had to explain the problem three times, or whether the issue passed through four teams before reaching somebody who could help. So measure the experience as well as the process.
+An SLA can tell you that the organisation responded within four hours. It cannot tell you whether the response was useful, whether the customer had to explain the problem three times, or whether the issue passed through four teams before reaching somebody who could help. **So measure the experience as well as the process.**
 
 Touchpoint measures such as transactional NPS are much better at this. You ask a question or two immediately after a real interaction, while the person still remembers what happened and can tell you which part of it was painful.
 
@@ -201,7 +201,7 @@ Ownership is unclear, so the customer is passed from one department to another. 
 
 None of those things is the customer's fault.
 
-Asking an employee to confirm their employee number, manager, department, device type, and office location may sound harmless. If all that information already exists inside your systems, you are asking the customer to compensate for your inability to retrieve it.
+Asking an employee to confirm their employee number, manager, department, device type, and office location may sound harmless. **If all that information already exists inside your systems, you are asking the customer to compensate for your inability to retrieve it.**
 
 The phrase "our process requires" should always make us suspicious. Sometimes the requirement is legitimate. Quite often, it is simply an old decision nobody has challenged.
 
@@ -215,7 +215,7 @@ This is also why user experience matters far beyond the appearance of software. 
 
 Where does the customer begin? Do they understand what is being asked? Does the service behave as they expect? What happens when they make a mistake? Can they tell whether something worked, and do they know what will happen next?
 
-Most bad experiences were not deliberately designed to be bad. They emerged because each team built its own part, optimised its own step, and assumed somebody else was responsible for the journey as a whole.
+**Most bad experiences were not deliberately designed to be bad.** They emerged because each team built its own part, optimised its own step, and assumed somebody else was responsible for the journey as a whole.
 
 Someone must own the experience across the boundaries.
 
@@ -239,7 +239,7 @@ Thinking in systems means looking beyond the immediate symptom. Ask what conditi
 
 Look for where one part has been optimised at the expense of the whole. Think about what unintended behaviour your proposed solution might create.
 
-This matters particularly inside large organisations. Individual teams frequently make perfectly rational decisions that combine to create an irrational customer experience.
+This matters particularly inside large organisations. **Individual teams frequently make perfectly rational decisions that combine to create an irrational customer experience.**
 
 Every department protects its own capacity with another approval. Every function creates its own intake form. Every system demands its own copy of the data.
 
@@ -247,7 +247,7 @@ Each team meets its local target while the customer carries the accumulated weig
 
 The Cynefin framework is one of the most useful tools I have found for thinking about how to respond to different kinds of problems.
 
-Its value is not in giving every situation a clever label. It is in recognising that different conditions require different methods.
+Its value is not in giving every situation a clever label. **It is in recognising that different conditions require different methods.**
 
 Some problems are clear enough that established practice, standardisation, and automation are appropriate. Some are complicated and require expertise and analysis.
 
@@ -273,7 +273,7 @@ Businesses contain load-bearing walls too. They are the odd approval, the strang
 
 Somebody new takes ownership, sees an apparently irrational arrangement, and quite reasonably decides to simplify it.
 
-Sometimes they are right. The arrangement may be outdated, badly conceived, or the result of a lazy decision made years ago. It may also be an intentional compromise that is carrying a load nobody has noticed.
+Sometimes they are right. The arrangement may be outdated, badly conceived, or the result of a lazy decision made years ago. **It may also be an intentional compromise that is carrying a load nobody has noticed.**
 
 Chesterton's fence is another way of expressing the same idea. You encounter a fence across a field and cannot see why anybody put it there.
 
@@ -291,7 +291,7 @@ If you cannot find the explanation, study harder and try to reconstruct it.
 
 The absence of documentation is not proof that there was no reasoning.
 
-This does not mean preserving every inherited process through misplaced reverence. Organisations accumulate plenty of nonsense. It means understanding something before changing it, particularly where the consequences might travel further than the change itself.
+This does not mean preserving every inherited process through misplaced reverence. Organisations accumulate plenty of nonsense. **It means understanding something before changing it, particularly where the consequences might travel further than the change itself.**
 
 A decision that appears inefficient may have been protecting reliability. A duplicated responsibility may have been compensating for a control weakness. A manual step may exist because an automated one previously caused damage.
 
@@ -323,7 +323,7 @@ Months later, somebody encounters the result and cannot understand why it exists
 
 There are legitimate reasons for working privately. Personal matters, commercially sensitive discussions, security incidents, and genuinely confidential subjects need appropriate protection.
 
-Privacy should be a deliberate control applied for a reason. It should not be the default setting for ordinary work.
+**Privacy should be a deliberate control applied for a reason.** It should not be the default setting for ordinary work.
 
 My friend and former colleague Jesse Taylor once captured the question brilliantly: "What are they afraid of?" It is worth asking whenever a team habitually works behind closed doors.
 
@@ -339,7 +339,7 @@ Assume they will need to search for your reasoning without knowing your name, th
 
 Could they find it? Could they understand how you reached the decision, or would they find only the final artefact and be left to guess?
 
-Closed channels and direct messages create a similar problem to the person who never takes time off. Knowledge remains concentrated around particular individuals.
+Closed channels and direct messages create a similar problem to the person who never takes time off. **Knowledge remains concentrated around particular individuals.**
 
 The organisation appears to function while they are present, but struggles to reproduce their understanding without them.
 
@@ -365,7 +365,7 @@ A person can look at an incomplete request and infer what the customer probably 
 
 Software cannot operate on folklore.
 
-To automate a process, you have to define the inputs, ownership, decisions, exceptions, and desired outcome. You have to confront the places where the organisation depends on context that exists only in somebody's head.
+**To automate a process, you have to define the inputs, ownership, decisions, exceptions, and desired outcome.** You have to confront the places where the organisation depends on context that exists only in somebody's head.
 
 Automation can therefore be a forcing function for better process and systems design.
 
@@ -373,7 +373,7 @@ The objective is not to reproduce every existing step in software. It is to ques
 
 Do we need this approval? Why are we asking for information we already have? Why does the work pass through three queues? Why does a person have to decide which team receives it?
 
-Bad automation makes a poor process move faster. Good automation forces you to define a better process.
+Bad automation makes a poor process move faster. **Good automation forces you to define a better process.**
 
 This principle matters even where you do not ultimately automate everything. The attempt forces clarity. It makes the team agree on ownership, inputs, and outcomes. It reveals exceptions that have quietly become the normal way of operating.
 
@@ -421,13 +421,13 @@ I am not suggesting you stop rescuing the customer. Everything else in this arti
 
 The difficulty is that the rescue usually appears to cost nothing and leaves no trace. Somebody spots the malformed request, knows from experience which team it actually belongs to, forwards it, and gets on with their day. The customer is served, the report looks fine, and the thing that caused it is exactly as broken tomorrow morning.
 
-So do the rescue, and then make it expensive to ignore. Record what happened. Note what the person had to know and what they had to do, because that is a fairly precise specification for whatever should have handled it instead. Count how often it happens and put that number alongside the others you review each week.
+**So do the rescue, and then make it expensive to ignore.** Record what happened. Note what the person had to know and what they had to do, because that is a fairly precise specification for whatever should have handled it instead. Count how often it happens and put that number alongside the others you review each week.
 
 Work with a number attached to it gets prioritised. Work that lives in somebody's head and costs them ten minutes a day does not, because those ten minutes belong to them rather than to the business.
 
 Heroics are useful during an incident. They are a terrible operating model.
 
-If you want to understand how much of your service depends on people covering for it, you can go looking on purpose, at a time you choose rather than one a customer chooses for you. Send a badly formed request through and see where it ends up. Ask the person who always knows to stay out of it for a fortnight.
+**If you want to understand how much of your service depends on people covering for it, you can go looking on purpose, at a time you choose rather than one a customer chooses for you.** Send a badly formed request through and see where it ends up. Ask the person who always knows to stay out of it for a fortnight.
 
 Holidays do this for nothing. Very little reveals an undocumented process quite like the person who holds it being genuinely unavailable, which is one of the reasons I care so much about people taking their leave.
 
@@ -441,7 +441,7 @@ I do not think that is right. It is far more useful to think about technical deb
 
 Debt is a tool. It is a large part of what drives an economy and, used sensibly, it is what allows a business to do something this year rather than in three years' time. Taking some on is usually evidence of a deliberate choice about speed, not evidence of carelessness.
 
-What people forget is what happens after the decision. When you create something, you own it. It has to be maintained, patched, understood, documented, explained to whoever arrives next, and eventually replaced. Nothing you build exists for free, and the bill does not arrive on the day you build it. It arrives every month afterwards, for as long as the thing survives.
+What people forget is what happens after the decision. When you create something, you own it. It has to be maintained, patched, understood, documented, explained to whoever arrives next, and eventually replaced. **Nothing you build exists for free, and the bill does not arrive on the day you build it.** It arrives every month afterwards, for as long as the thing survives.
 
 There is nothing wrong with having a mortgage on your house. What is not fine is having a mortgage you cannot afford.
 
@@ -451,7 +451,7 @@ It also compounds. The more you are carrying, the more separate things demand at
 
 Refusing to make these decisions does not simply slow the work down, it chokes the creativity out of a team. Nobody offers up the interesting idea when they already know there is no room to build it, and watching your week disappear into servicing decisions somebody else avoided making is thoroughly demoralising. That is a more expensive loss than the debt itself, and a much harder one to reverse.
 
-So be selective about what you take on, and be equally intentional about what you are prepared to remove. Most organisations are considerably better at adding than they are at subtracting.
+So be selective about what you take on, and be equally intentional about what you are prepared to remove. **Most organisations are considerably better at adding than they are at subtracting.**
 
 Have one CRM, not three. Pick Microsoft or Google, not both. Teams or Zoom for your meetings, not both. Normalise where you can and actually make the call, because the alternative is quietly agreeing to feed all of it forever.
 
@@ -471,7 +471,7 @@ Some examples that are top of mind for me at the moment. Anthropic: come for the
 
 To be clear, I have no objection to tools that do lots of things. Those are all good products, and breadth is frequently exactly what you want.
 
-What I dislike is the tool you allow through the door for one purpose, which then creeps unintentionally into an increasing number of corners of your business. Nobody sits down and decides to do this. It happens one sensible convenience at a time.
+**What I dislike is the tool you allow through the door for one purpose, which then creeps unintentionally into an increasing number of corners of your business.** Nobody sits down and decides to do this. It happens one sensible convenience at a time.
 
 Every one of those small conveniences makes the relationship a little stickier. That is fine while the tool is the best available answer. It becomes a problem when the tool grows, as tools do, and the part you depend on starts to lag behind. By that point you are no longer making a decision about one product. You are making a decision about nine things you had not really noticed you were buying.
 
@@ -493,7 +493,7 @@ I do not outright reject all-in-one tools. In fact, some all-in-one tools can be
 
 Years ago, Rob came back from a shop in Shoreditch with a poster that said, "Work hard and be nice to people." It is difficult to improve on that as a philosophy for doing business.
 
-Working hard while treating people badly creates a culture of ego, fear, and burnout. Being nice without doing the work creates a pleasant but ineffective organisation. You need both.
+**Working hard while treating people badly creates a culture of ego, fear, and burnout.** Being nice without doing the work creates a pleasant but ineffective organisation. You need both.
 
 Being nice does not mean avoiding difficult conversations, tolerating poor performance, or agreeing to every request. It means treating people with respect. It means being direct without being cruel and remembering that the person at the other end of a difficult situation is still a person.
 
@@ -525,7 +525,7 @@ Respect your sales team. They bring in the calories that keep the company going.
 
 That does not put them beyond criticism. Bad sales behaviour can create enormous problems for customers and delivery teams. Overpromising or selling work that cannot be delivered destroys trust.
 
-The respect has to work both ways. Sales must respect the people who fulfil the promises, and delivery must respect the people who create the opportunity to make those promises.
+**The respect has to work both ways.** Sales must respect the people who fulfil the promises, and delivery must respect the people who create the opportunity to make those promises.
 
 Acquiring, serving, and retaining a customer are not separate activities. They are parts of the same system.
 
@@ -547,7 +547,7 @@ The official [Level 10 Meeting structure is explained here](https://www.eosworld
 
 The power comes from discipline rather than novelty.
 
-The meeting happens at the same time, follows the same structure, and ends on time. Status updates do not consume the space intended for solving problems.
+**The meeting happens at the same time, follows the same structure, and ends on time.** Status updates do not consume the space intended for solving problems.
 
 Issues are captured rather than allowed to derail the meeting, then prioritised so that the team works on what matters most rather than simply starting at the top of a list.
 
@@ -559,7 +559,7 @@ In an in-person meeting, that meant putting away technology. That principle is h
 
 I try to recreate the spirit of it by running the meeting through a shared Miro board or something similar. Everybody is looking at and contributing to the same workspace rather than disappearing into private notes, email, or Slack while the meeting happens around them.
 
-The structure only works when you respect it. If every issue is discussed the moment it appears, if actions remain permanently incomplete, or if the meeting routinely overruns, it gradually becomes an ordinary meeting with some EOS terminology attached.
+**The structure only works when you respect it.** If every issue is discussed the moment it appears, if actions remain permanently incomplete, or if the meeting routinely overruns, it gradually becomes an ordinary meeting with some EOS terminology attached.
 
 I have introduced a lot of people to properly run Level 10 meetings over the years. Almost every time, somebody remarks that it is one of the best meetings they have ever attended.
 
@@ -577,7 +577,7 @@ I was building something, solving something, or carrying responsibility for some
 
 COVID rotated my priorities.
 
-Like many people, I was forced to stop and look differently at how I had been spending my time. I realised that I had missed a meaningful chunk of my children's lives by being so immersed in work. That is not time you can recover later.
+Like many people, I was forced to stop and look differently at how I had been spending my time. I realised that I had missed a meaningful chunk of my children's lives by being so immersed in work. **That is not time you can recover later.**
 
 Children do not pause while you finish an important period in your career. They do not stay the same age while you get through a difficult quarter, complete an acquisition, or wait for the business to become less demanding.
 
@@ -621,7 +621,7 @@ Avoid spending the holiday physically beside your family while mentally remainin
 
 Your family experiences your relationship with work even though they have no involvement in the business. They experience the cancelled plans, the half-present parent, the laptop at the dinner table, and the holiday spent checking messages beside the pool.
 
-If the organisation genuinely cannot function for a week without you, that is not simply evidence of your importance. It is evidence that you have built a fragile system.
+**If the organisation genuinely cannot function for a week without you, that is not simply evidence of your importance.** It is evidence that you have built a fragile system.
 
 Taking leave exposes unclear ownership, missing documentation, and decisions that have been unnecessarily centralised. That can be uncomfortable, but it is useful information.
 
@@ -675,7 +675,7 @@ The underlying organisational risk is still real.
 
 Sometimes people make themselves indispensable because they cannot, or will not, build a machine that operates beyond them. They hold processes in their heads, become the only person with access to a system, and personally intervene whenever something goes wrong. They answer every question, approve every decision, and quietly compensate for weaknesses in the operation. This can happen without any bad intent.
 
-In fact, it is often the most conscientious and productive people who create the greatest hidden risk. They care deeply, work incredibly hard, and solve problems before anybody else knows those problems exist. Their productivity shields the fragility beneath them.
+In fact, it is often the most conscientious and productive people who create the greatest hidden risk. They care deeply, work incredibly hard, and solve problems before anybody else knows those problems exist. **Their productivity shields the fragility beneath them.**
 
 At a glance, they appear to be your top performers. The work gets done, customers are happy, and problems disappear. The person appears irreplaceable.
 
@@ -693,7 +693,7 @@ A genuinely great performer does not merely produce an exceptional volume of wor
 
 They make the people and systems around them more capable. They document what they know, distribute authority, train successors, and reduce the organisation's dependence on their continued presence. Their absence may be felt, but it should not cause the machinery to stop.
 
-Mandatory leave, proper handovers, and sensible job rotation are not signs that you distrust people. They are healthy controls. They expose undocumented work, weak segregation of duties, and responsibilities that have become dangerously concentrated in one person.
+**Mandatory leave, proper handovers, and sensible job rotation are not signs that you distrust people.** They are healthy controls. They expose undocumented work, weak segregation of duties, and responsibilities that have become dangerously concentrated in one person.
 
 Encourage people to take leave. Scrutinise those who consistently refuse.
 

--- a/src/content/posts/the-rules-i-try-to-do-business-by.mdx
+++ b/src/content/posts/the-rules-i-try-to-do-business-by.mdx
@@ -91,12 +91,6 @@ You cannot improve an experience you have arranged never to receive.
 
 Yeah yeah, I know, it's a cliché, but that's because it's true!
 
-The first interaction establishes the customer's mental model of everything that follows. It tells them whether you are attentive, competent, organised, and interested.
-
-A poor first impression creates a trust deficit that you may spend months correcting. A good one creates confidence and buys a certain amount of patience for the day when something inevitably goes wrong. This applies to the first sales conversation, the onboarding experience, the first screen of an application, and the first time an employee contacts an internal support team.
-
-Customers do not experience your strategy deck. They experience moments.
-
 Dom Monkhouse once told me a story from an acquisition due diligence exercise. He had gone to visit a small business and, immediately inside the front door, was a staircase leading up into the office.
 
 Sitting on the stairs were four copies of the Yellow Pages.
@@ -142,6 +136,12 @@ So go and look for your own Yellow Pages moments. Walk in through your own front
 Then ask what they are telling people. What is your team learning about the standard you will accept, simply by watching what you walk past? What are you telling the world your tolerance allows?
 
 Where is your bar? Not the one written into your values or your strategy deck. The one your team can see from where they are sitting.
+
+The first interaction establishes the customer's mental model of everything that follows. It tells them whether you are attentive, competent, organised, and interested.
+
+A poor first impression creates a trust deficit that you may spend months correcting. A good one creates confidence and buys a certain amount of patience for the day when something inevitably goes wrong. This applies to the first sales conversation, the onboarding experience, the first screen of an application, and the first time an employee contacts an internal support team.
+
+Customers do not experience your strategy deck. They experience moments.
 
 Customers cannot see most of what happens inside a service provider. They cannot inspect your architecture, internal controls, project plan, or the quality of the discussions taking place behind the scenes. They make judgements from the evidence available to them, and that evidence often consists of tiny details.
 
@@ -485,7 +485,7 @@ All of this is far easier to describe than to do. Vendors work extremely hard at
 
 So stay on top of it. Look at your ecosystem as a whole rather than one renewal at a time, and make the calls intentionally. Sometimes consolidating is exactly right and you should do it enthusiastically. Sometimes it is not, and the specialist tool has earned its place on the invoice.
 
-The point is to decide, rather than to arrive somewhere by accumulation.
+I do not outright reject all-in-one tools. In fact, some all-in-one tools can be amazing, especially line of business systems with highly opinionated blueprints such as ConnectWise. But it should be a decision to go all-in-one in itself, not a decision to get each tool then stumble into an all-in-one.
 
 ## Look after the people
 
@@ -569,15 +569,7 @@ Give meetings a purpose, a rhythm, and a method for reaching decisions. Respect 
 
 ### Take time off, and do it properly
 
-Take your holiday.
-
-Spread it throughout the year, book it well in advance where you can and, when the time comes, actually take it. This is especially important if you have a family.
-
-It is very easy to let work consume the calendar. There is always a significant customer opportunity, a difficult project, a quarter end, a budget cycle, or some problem that apparently cannot survive your absence.
-
-Leave enough empty space in the diary and work will happily fill all of it.
-
-For a long time, I allowed that to happen.
+For a long time I let work be my number one focus, because I enjoyed what I was doing and honestly I was a bit addicted. It was the majority of Wirehive's growth and it was exhilarating and consuming.
 
 I immersed myself in work and treated the demands of the business as though they naturally deserved first call on my time. There was always a good justification.
 
@@ -590,6 +582,14 @@ Like many people, I was forced to stop and look differently at how I had been sp
 Children do not pause while you finish an important period in your career. They do not stay the same age while you get through a difficult quarter, complete an acquisition, or wait for the business to become less demanding.
 
 The years pass whether you make room for them or not.
+
+Take your holiday.
+
+Spread it throughout the year, book it well in advance where you can and, when the time comes, actually take it. This is especially important if you have a family.
+
+It is very easy to let work consume the calendar. There is always a significant customer opportunity, a difficult project, a quarter end, a budget cycle, or some problem that apparently cannot survive your absence.
+
+Leave enough empty space in the diary and work will happily fill all of it.
 
 My balance is different now. I deliberately prioritise securing quality time with my family.
 

--- a/src/content/posts/the-rules-i-try-to-do-business-by.mdx
+++ b/src/content/posts/the-rules-i-try-to-do-business-by.mdx
@@ -647,7 +647,7 @@ Work matters. So does the life the work is meant to support.
 
 ### A note on working from home
 
-My own balance includes working from home on Monday and Friday, while spending Tuesday to Thursday in the office with my team. That arrangement is deliberate. I value the flexibility of working from home, but I have also become increasingly convinced that it carries a real cost to learning, relationships, and the development of teams.
+My own balance includes working from home on Monday and Friday, while spending Tuesday to Thursday in the office with my team. That arrangement is something I've come around to over the course of the last five and a half years following COVID. I value the flexibility of working from home, but I have also become increasingly convinced that it carries a real cost to learning, relationships, and the development of teams.
 
 **A note from me:** This section originally became a much longer part of this article. The more I wrote, the more obvious it became that it did not quite belong here. I also realised that I felt far too strongly about it to reduce it to a few comfortable paragraphs.
 

--- a/src/content/posts/the-rules-i-try-to-do-business-by.mdx
+++ b/src/content/posts/the-rules-i-try-to-do-business-by.mdx
@@ -7,7 +7,7 @@ toc: true
 ---
 import Callout from '../../components/Callout.astro';
 
-<Callout variant="neutral" icon="😤">
+<Callout variant="neutral" icon="😬">
   I have realised while writing this that it's become a blend of "here's some things I've learned" and "you know what really grinds my gears?". I didn't intend for this to be a rant, but it does get a bit ranty in places. I've decided I'm ok with that :)
 
   I've written this over the last week or so through a combination of Apple Notes on the fly, dictating at ChatGPT and Claude when a thought comes up and having it capture it, intentional writing and rethinking, and some final polish to try and organise it all together. I was pretty taken aback when I realised how long it had got. I contemplated breaking it up into separate pages, but that just seems gratuitous (though I did break out one point :D ). And besides, I think I'll come back to this over time and keep it up to date as well.

--- a/src/content/posts/working-from-home-holds-your-learning-back.mdx
+++ b/src/content/posts/working-from-home-holds-your-learning-back.mdx
@@ -169,7 +169,7 @@ The centre of gravity is the office. The team spends most of the working week to
 
 I currently work from the office with my team from Tuesday to Thursday. Monday and Friday are my home-working days.
 
-Those office days are coordinated. This matters.
+Those days are coordinated with everyone else. It's not "Pick 3", we are all in on the same days. Some more.
 
 Five people who each attend the office on a different day have not formed an office-based team. They have simply changed the location from which they work alone.
 

--- a/src/content/posts/working-from-home-holds-your-learning-back.mdx
+++ b/src/content/posts/working-from-home-holds-your-learning-back.mdx
@@ -1,0 +1,332 @@
+---
+title: "Working From Home Holds Your Learning Back"
+description: "Output is not the same as potential. Full-time home working weakens passive learning, flattens the development curve, and does younger workers a disservice."
+date: 2026-08-01
+tags: ["leadership", "culture", "future-of-work", "workforce", "careers"]
+---
+
+This article began as one section of a much broader piece called [The Rules I Try to Do Business By](/writing/the-rules-i-try-to-do-business-by/).
+
+It was supposed to explain why I spend three days a week in the office with my team, despite appreciating the flexibility of working from home myself. It kept growing. The more I wrote, the more obvious it became that it did not quite fit with the rest of the article. More importantly, I realised I felt far too strongly about the subject to hide it halfway down a much longer page.
+
+So I broke it out and gave it the space it deserves.
+
+My position is straightforward: working from home full time holds your learning back.
+
+There, I said it, and I stand by it.
+
+I have tried working fully remotely. People working for me have tried it. Over the years I have permitted myself and others all sorts of working patterns, from almost entirely remote through to almost entirely office-based.
+
+Nothing I have experienced has beaten the feedback, pace of learning, and strength of relationships you get from a group of people regularly working together in person.
+
+That does not mean people cannot be productive at home. In fact, I absolutely believe that immediate individual output is often higher when somebody works remotely and has a quiet, distraction-free environment.
+
+There is no commute. Fewer people interrupt you. You can settle into a difficult piece of work and stay there for hours. For certain kinds of focused individual activity, home can be an excellent place to work.
+
+I appreciate those benefits myself. I work from home two days a week.
+
+The mistake is treating immediate individual output as the whole measure of whether a working arrangement is effective.
+
+I think that is a profoundly short-term view.
+
+## Output is not the same as potential
+
+It is easy to measure what somebody produced this week. It is much harder to measure the knowledge they did not acquire, the relationships they did not build, and the opportunities they never discovered.
+
+A person can produce a great deal of work while learning very little. They can complete every assigned task, attend every scheduled meeting, and appear perfectly productive while becoming only marginally more capable than they were six months earlier.
+
+Output tells you what somebody can do now. It does not necessarily tell you what they are becoming capable of doing.
+
+Think about how talent scouts assess players in a team sport. They are not only interested in the score from the last match or the player's output at that exact moment. They are looking at movement, awareness, decision-making, temperament, coachability, and potential. They are asking what this person might become in the right environment.
+
+We should think about people at work in much the same way.
+
+Of course current performance matters. Businesses have work to do and customers to serve. But a good organisation should also be increasing the capability of the people inside it.
+
+If somebody joins your company, gives you several years of their working life, and leaves with roughly the same breadth of capability they arrived with, I think you have failed them.
+
+One of my favourite things about running a business and leading teams is developing people. I enjoy discovering what somebody is interested in, giving them room to explore it, and watching that interest gradually become capability, confidence, and sometimes a completely new direction in their career.
+
+I think we owe that to one another.
+
+Work should not be a purely transactional exchange in which somebody completes the tasks attached to their job description and receives a salary in return. We spend too much of our lives working for that to be the full extent of the relationship.
+
+The people around us should help us become more capable, and we should be looking for opportunities to do the same for them.
+
+I do not believe we can do that as effectively when the seed of every conversation first depends on somebody booking a meeting.
+
+## Most workplace learning is not scheduled
+
+A huge amount of learning at work is passive.
+
+A junior employee sitting near a finance team will absorb fragments of how finance works without anybody arranging a training session. They hear people discussing budgets, margins, forecasting, purchase orders, and the difference between revenue and cash.
+
+Much of it may have nothing to do with their immediate role. Over time, those fragments accumulate into a broader understanding of how a business actually operates.
+
+The same thing happens across engineering, sales, product, operations, and leadership.
+
+You overhear a problem being discussed and learn how somebody more experienced approaches it. You notice how a difficult conversation is handled. You see which details senior people care about and which they dismiss. You hear a customer objection, a commercial trade-off, or an operational problem that would never have appeared in your development plan.
+
+None of this is formal training. Much of it is never deliberately taught.
+
+It is still a significant part of how people become good.
+
+Some of the most valuable development starts with a conversation nobody would ever have thought to schedule. Somebody mentions a problem, asks a small question, or shows an interest in something happening nearby. That creates an opening for a story, an explanation, a piece of advice, or an invitation to become involved.
+
+Those moments are seeds. Some go nowhere. Others alter careers.
+
+A calendar invitation creates a threshold. The conversation needs a purpose, a title, and enough perceived importance to claim time from two diaries.
+
+Many of the conversations that help people develop never cross that threshold. They are too small, too speculative, or too loosely formed.
+
+In an office, they can begin with somebody leaning across a desk and saying, "Can I ask you something?"
+
+That question might take thirty seconds. It might become a useful five-minute conversation. Somebody else nearby may hear it and add the missing piece. A misunderstanding may be corrected before it becomes a week of wasted work.
+
+Remotely, the same question has to become an event.
+
+You check calendars. You send a message or arrange a call. You wait. By the time the conversation happens, the moment may have passed, or the person may have decided the question was not important enough to ask.
+
+Remote working does not make coaching or career development impossible. A good manager can schedule regular one-to-ones, create mentoring schemes, and make deliberate space for development.
+
+The problem is that deliberate development mostly addresses needs and interests we already know exist.
+
+It is much worse at discovering the curiosity, misunderstandings, and unexpected interests that become visible simply because people spend time together.
+
+## We are doing younger workers a disservice
+
+I think putting younger people into full-time home working does them a profound disservice.
+
+We take somebody out of education, place them at a desk in their bedroom or spare room, and then expect them somehow to become competitively capable in the ways of work and business.
+
+We give them a set of scheduled meetings, a stream of messages, and a narrowly defined list of responsibilities. Then we wonder why they do not develop the broader instincts that previous generations acquired through years of being surrounded by working life.
+
+It puts the narrowest possible set of blinkers on them.
+
+They see the work assigned to them. They attend the meetings somebody else has decided they need to attend. They speak mostly to the people directly connected to their role.
+
+What they miss is almost everything happening at the edges.
+
+They do not overhear the sales team discussing why a deal was lost. They do not hear finance challenge the assumptions behind a forecast. They do not watch an experienced manager calm a difficult situation or notice how a senior engineer approaches a problem before touching the technology.
+
+They do not build the dozens of weak relationships across a business that gradually become an understanding of how the whole thing really works.
+
+People who were established before COVID can easily underestimate this cost.
+
+We entered remote working with years of accumulated context, confidence, and relationships already behind us. We knew how organisations behaved, who to contact, how to read a room, and which unwritten rules mattered.
+
+We could make remote working function because we had built much of the foundation in person.
+
+Somebody entering working life from home does not have that foundation. Asking them to recreate it through Teams calls and Slack messages is not an equivalent experience.
+
+We benefited from an environment and then removed that environment for the generation following us.
+
+I do not think that is fair.
+
+## Remote work can flatten development
+
+One of my concerns with fully remote employment is that the development curve can become remarkably flat.
+
+A person joins a company and learns a great deal at first. They have to understand the systems, people, products, and immediate responsibilities of the role. There is an initial burst of development because nearly everything is new.
+
+Then the curve begins to level out.
+
+They continue to become more efficient at the work already assigned to them, but they receive much less exposure to adjacent areas. They may become better at that particular job inside that particular company without becoming significantly broader in their trade or more commercially capable.
+
+Their world becomes the work directed towards them.
+
+In that situation, moving to another company can become one of their largest development events. Suddenly there is a new set of systems, people, expectations, and problems. Their learning accelerates again because the environment has changed.
+
+That is not necessarily bad. Moving between companies has always been an important source of development.
+
+The problem is when changing employer becomes one of the only reliable ways to achieve meaningful breadth.
+
+When you work in an office full of people, you are passively developing all the time. You encounter ideas, professions, problems, and perspectives beyond your immediate responsibility. You learn your own trade, but you also learn enough about the work around it to become more effective.
+
+You begin to understand finance, sales, people management, operations, and customers through exposure rather than a formal course.
+
+Remote work can make a job narrower without anybody consciously choosing to narrow it.
+
+That may not appear in this quarter's productivity figures. It becomes visible later, in the gap between somebody's current output and the potential they might have developed.
+
+## Relationships make work faster
+
+The value of working together is not limited to learning.
+
+Relationships built through regular proximity create shortcuts.
+
+You learn how somebody thinks, what they know, and how they prefer to communicate. You understand their intent more quickly because each conversation rests on months or years of shared context.
+
+A brief exchange can carry a surprising amount of information when the relationship underneath it is strong.
+
+That matters when work becomes difficult or urgent. Teams that know one another well can move quickly without every interaction becoming formal. They can challenge one another more directly because trust already exists. They can resolve ambiguity without writing a miniature contract around every request.
+
+Before COVID, I experienced tightly connected teams that could move at remarkable speed.
+
+People shared context almost continuously. Problems were surfaced early. Knowledge travelled quickly. The distinction between working and learning was often invisible because both were happening at the same time.
+
+I have not been able to recreate those dynamics fully since COVID.
+
+Remote tools have improved enormously. Disciplined distributed teams can do excellent work. I work for a global company and rely on those tools every day. Geography gives us access to people and expertise that would otherwise be unavailable.
+
+Even so, every person who cannot regularly work alongside the rest of a team represents a compromise of some form.
+
+The compromise may be entirely justified. The individual may be exceptional. The skill may be scarce. The company may operate across several countries, with no realistic prospect of putting everybody in one place.
+
+It is still a compromise.
+
+We should be honest about that rather than pretending every working arrangement produces the same result.
+
+## This is not what I mean by a hybrid team
+
+The language around hybrid work has become unhelpfully vague.
+
+A company can describe almost any arrangement as hybrid. People may work all over the country, visit an office occasionally, and meet once a week on a video call. A globally distributed team may gather in person every six months. Another team may attend a building on different days and rarely see one another.
+
+That is not the model I am describing.
+
+I am talking about an in-office team that is allowed to work from home twice a week.
+
+The centre of gravity is the office. The team spends most of the working week together. Home working provides flexibility around that shared rhythm rather than replacing it.
+
+I currently work from the office with my team from Tuesday to Thursday. Monday and Friday are my home-working days.
+
+Those office days are coordinated. This matters.
+
+Five people who each attend the office on a different day have not formed an office-based team. They have simply changed the location from which they work alone.
+
+For a while, I encouraged people to spend time in the office. I no longer merely encourage it. For people working locally on my team, I require three days out of five together.
+
+I make that requirement because I believe it creates better conditions for learning, development, relationships, and long-term team performance.
+
+It is not a rejection of flexibility. I value flexibility and use it myself.
+
+It is an attempt to keep the benefits of home working without pretending there is no cost when people stop spending meaningful time together.
+
+## Office days do not need to justify themselves
+
+I also reject the argument that every day in the office needs to be carefully programmed to justify the commute.
+
+If a globally distributed team meets in person once every six months, or worse, once a year, then of course you should make the most of it.
+
+Plan the time carefully. Bring the right people together. Have the difficult conversations, build the relationships, and squeeze as much value as possible from a scarce opportunity.
+
+That is not the same thing as regularly working together in an office.
+
+When people are together three days a week, every week, the greatest gift is simply that they are there.
+
+The value does not need to be scheduled in advance. It emerges from the ordinary rhythm of people working alongside one another.
+
+Before COVID, we did not create elaborate agendas to prove that an office day had delivered sufficient value. We went to work. The value happened around us.
+
+Somebody overheard a conversation and contributed the missing piece. A junior employee asked a question because the right person happened to be nearby. Two people realised they were solving related problems. A misunderstanding was corrected before it became a week of wasted effort.
+
+Somebody joined a discussion they would never have been invited to because nobody knew in advance that their experience would be useful.
+
+These are not distractions from the value of an office. They are much of the value.
+
+Serendipity requires repeated proximity.
+
+It works because people share space often enough for conversation to be cheap, informal, and unremarkable. Nobody has to decide whether a thought deserves a meeting. Nobody has to identify every relevant participant before the conversation begins.
+
+The connections form themselves.
+
+When office attendance is rare, it becomes an event. Events need agendas, objectives, and visible returns.
+
+Regular attendance is different. It creates an environment, and that environment produces value continuously, including value you could never have planned because you did not know in advance that it was available.
+
+There will be days when I spend much of my time on calls with people elsewhere in the world. That does not make being in the office pointless.
+
+I am still available to the people around me before the call, after it, and in the gaps between. I still overhear, notice, answer, ask, and contribute. So do they.
+
+The test of an office day should not be whether every hour contained an activity that could only have happened in person.
+
+That sets an absurd standard we never applied before COVID.
+
+The value is in making shared presence normal again. Once it is normal, the valuable moments stop needing to be engineered.
+
+## Convenience is not the only responsibility
+
+I know this is not the most popular position in every organisation.
+
+The conversation about office working has often become moralised, as though flexibility is inherently enlightened and asking people to work together in person is inherently regressive.
+
+I do not accept that framing.
+
+There are genuine trade-offs.
+
+Home working gives people valuable autonomy. It can improve the balance of their lives and make focused work easier. It can remove a long commute, allow somebody to walk the dog, or make it possible to run an errand during the day.
+
+Those benefits are real.
+
+Working together in person accelerates learning, creates broader context, strengthens relationships, and produces a kind of team cohesion I have not seen technology reproduce.
+
+Those benefits are real too.
+
+My job as a leader is not simply to choose the arrangement people find most convenient at this exact moment. It is to create the conditions in which people, teams, and the organisation can become better over time.
+
+That requires thinking beyond immediate output.
+
+It requires asking whether people are developing towards their potential, whether knowledge is travelling across the team, and whether younger employees are being given a fair opportunity to learn how work actually works.
+
+Most importantly, we have a responsibility not to offer younger people convenience at the expense of their development.
+
+They deserve the chance to build the breadth of knowledge, confidence, and relationships that many of us acquired by being surrounded by working life.
+
+After trying the alternatives, I believe that requires spending a meaningful part of the week together.
+
+Not gathering periodically. Not meeting once a week. Not working remotely and occasionally attending an office event.
+
+Working together, in an office, as the normal way the team operates, with the option to work from home twice a week.
+
+So much of what I understand about how a business actually works, I picked up in rooms I never had to book. A conversation I overheard. A question I asked because the right person happened to be sitting nearby. An argument I watched somebody handle better than I would have.
+
+Nobody planned any of it for me. It was simply there, because I was.
+
+I would like the people starting out now to have the same chance.
+
+## Addendum: What the research says
+
+After re-reading this a few times, I thought to myself, "Yep, I stand by all of this strongly. But… it's all rooted in my own observation." I got actually curious if this is just me or this is what the research shows too, so used my robot friend to help with some research. Imagine starting a research task with Google search in 2026.
+
+Turns out, I am far from alone in this line of thinking. Here are some up-to-date research outcomes supporting the claims I'm making here.
+
+**Immediate individual output really can be higher at home:** [Does Working from Home Work? Evidence from a Chinese Experiment](https://www.nber.org/papers/w18871)
+
+In this nine-month randomised experiment, call-centre employees working from home delivered 13% more output. Nine percentage points came from working more minutes per shift, with fewer breaks and sick days, while four came from handling more calls per minute in a quieter environment. Once people were allowed to choose the environment that suited them best, the gain rose to 22%, although home workers were still less likely to be promoted after accounting for their performance.
+
+This matches my observation. Give somebody clearly measurable individual work and a quiet, distraction-free home environment and their immediate output may rise substantially. That does not mean they are learning, they are helping, or they are becoming capable of doing much more.
+
+**Working together trades some immediate output for development and future quality:** [The Power of Proximity to Coworkers](https://academic.oup.com/qje/article/141/3/1825/8676722)
+
+Before offices closed, engineers sitting alongside their teammates received 23.9% more code-review comments than those whose teams were split between buildings. The advantage largely disappeared when everybody became remote, and the feedback lost was disproportionately useful, actionable, and well reasoned. Experienced engineers produced less code when sitting with colleagues, but younger, and less-tenured engineers received more help and subsequently produced better-quality work, achieving roughly twice the average improvement in code quality. Following a three-day office mandate, co-located engineers were also 1.4 percentage points less likely to introduce bugs and 2.2 points less likely to add files that were subsequently deleted.
+
+**Younger workers have more to lose from remote work:** [How Do Workers Learn? Theory and Evidence on the Roots of Lifecycle Human Capital Accumulation](https://www.nber.org/papers/w35199)
+
+This 2026 working paper uses German and US data to examine how learning changes over a career. It found that learning directly from coworkers matters most earlier in working life, and concluded that remote work disrupts this internal learning, and early-career wage growth. Formal training can offset some of the loss, but not all of it.
+
+**Learning from coworkers is a huge part of learning at work:** [Production and Learning in Teams](https://doi.org/10.3982/ECTA16748)
+
+Published in *Econometrica* in 2024, this research estimated that learning from coworkers accounts for around two-thirds of the human capital people accumulate while working. Less knowledgeable employees tend to catch up when they work with more knowledgeable colleagues, while the more knowledgeable person is not dragged backwards. In other words, putting capable people around developing people really does matter.
+
+**Remote work makes organisations more siloed:** [The Effects of Remote Work on Collaboration Among Information Workers](https://www.nature.com/articles/s41562-021-01196-4)
+
+Researchers analysed emails, messages, meetings, and calls involving 61,182 Microsoft employees. Full-time remote work made collaboration networks more static and siloed, with fewer bridges between different parts of the organisation. Communication also became less synchronous, making it harder for new information to travel across the business.
+
+**Serendipity and weak relationships have measurable value:** [The Effect of Co-location on Human Communication Networks](https://www.nature.com/articles/s43588-022-00296-z)
+
+During the loss of physical co-location at MIT, researchers measured the disappearance of more than 4,800 weak ties over 18 months. These are the loose connections between people in different parts of an organisation through which unfamiliar information and opportunities often travel. Partial co-location regenerated some of them, providing pretty compelling evidence that simply being around one another creates connections that remote tools do not reliably reproduce.
+
+**Video calls are not an equivalent environment for creating ideas:** [Virtual Communication Curbs Creative Idea Generation](https://www.nature.com/articles/s41586-022-04643-y)
+
+Across a laboratory experiment involving 602 people and a field experiment involving 1,490 engineers, pairs working over video generated fewer ideas and fewer creative ideas than pairs working face to face. Interestingly, virtual participants were not worse at selecting which idea to pursue once the ideas existed. The research suggests that different working modes may suit different kinds of work, but that video particularly inhibits the messy, expansive process of generating something new.
+
+**A loosely coordinated hybrid team is not the same as an office-based team:** [Employee Innovation During Office Work, Work From Home and Hybrid Work](https://www.nature.com/articles/s41598-024-67122-6)
+
+This study followed innovation activity across more than 48,000 employees. During full-time home working, people submitted a similar number of ideas but the average quality fell; during hybrid working, the number of ideas also fell. The effect was particularly bad in teams whose members attended the office on different days, supporting the point that five people independently visiting the same building do not constitute an in-office team.
+
+**A genuine three-and-two arrangement can preserve the useful flexibility:** [Hybrid Working From Home Improves Retention Without Damaging Performance](https://www.nature.com/articles/s41586-024-07500-2)
+
+This randomised trial involved 1,612 graduate employees working in engineering, marketing, accounting, and finance. Allowing people to work from home on two coordinated days each week reduced resignations by one-third and improved satisfaction, with no detected damage to performance ratings, promotion rates, or code output over the following two years. That is strikingly close to the model I advocate: an office-based team that works together for three days, with the option to work from home for two.
+
+None of this proves that every person, role, or organisation should operate in exactly the same way. There are jobs that suit remote work brilliantly, exceptional people worth hiring wherever they live, and enormous quality-of-life benefits from flexibility. However… Immediate individual output is not the same thing as long-term capability. Communication is not the same thing as connection. Scheduled training is not the same thing as learning continuously from the people around you. A distributed team that periodically meets is not the same thing as a group of people who normally work together.

--- a/src/content/posts/working-from-home-holds-your-learning-back.mdx
+++ b/src/content/posts/working-from-home-holds-your-learning-back.mdx
@@ -67,9 +67,7 @@ The same thing happens across engineering, sales, product, operations, and leade
 
 You overhear a problem being discussed and learn how somebody more experienced approaches it. You notice how a difficult conversation is handled. You see which details senior people care about and which they dismiss. You hear a customer objection, a commercial trade-off, or an operational problem that would never have appeared in your development plan.
 
-None of this is formal training. Much of it is never deliberately taught.
-
-It is still a significant part of how people become good.
+None of this is formal training. Much of it is never deliberately taught. It is still a significant part of how people become good.
 
 Some of the most valuable development starts with a conversation nobody would ever have thought to schedule. Somebody mentions a problem, asks a small question, or shows an interest in something happening nearby. That creates an opening for a story, an explanation, a piece of advice, or an invitation to become involved.
 
@@ -95,9 +93,7 @@ It is much worse at discovering the curiosity, misunderstandings, and unexpected
 
 ## We are doing younger workers a disservice
 
-I think putting younger people into full-time home working does them a profound disservice.
-
-We take somebody out of education, place them at a desk in their bedroom or spare room, and then expect them somehow to become competitively capable in the ways of work and business.
+I think putting younger people into full-time home working does them a profound disservice. We take somebody out of education, place them at a desk in their bedroom or spare room, and then expect them somehow to become competitively capable in the ways of work and business.
 
 We give them a set of scheduled meetings, a stream of messages, and a narrowly defined list of responsibilities. Then we wonder why they do not develop the broader instincts that previous generations acquired through years of being surrounded by working life.
 
@@ -107,19 +103,13 @@ They see the work assigned to them. They attend the meetings somebody else has d
 
 What they miss is almost everything happening at the edges.
 
-They do not overhear the sales team discussing why a deal was lost. They do not hear finance challenge the assumptions behind a forecast. They do not watch an experienced manager calm a difficult situation or notice how a senior engineer approaches a problem before touching the technology.
-
-They do not build the dozens of weak relationships across a business that gradually become an understanding of how the whole thing really works.
+They do not overhear the sales team discussing why a deal was lost. They do not hear finance challenge the assumptions behind a forecast. They do not watch an experienced manager calm a difficult situation or notice how a senior engineer approaches a problem before touching the technology. They do not build the dozens of weak relationships across a business that gradually become an understanding of how the whole thing really works.
 
 People who were established before COVID can easily underestimate this cost.
 
-We entered remote working with years of accumulated context, confidence, and relationships already behind us. We knew how organisations behaved, who to contact, how to read a room, and which unwritten rules mattered.
+We entered remote working with years of accumulated context, confidence, and relationships already behind us. We knew how organisations behaved, who to contact, how to read a room, and which unwritten rules mattered. We could make remote working function because we had built much of the foundation in person.
 
-We could make remote working function because we had built much of the foundation in person.
-
-Somebody entering working life from home does not have that foundation. Asking them to recreate it through Teams calls and Slack messages is not an equivalent experience.
-
-We benefited from an environment and then removed that environment for the generation following us.
+Somebody entering working life from home does not have that foundation. Asking them to recreate it through Teams calls and Slack messages is not an equivalent experience. We benefited from an environment and then removed that environment for the generation following us.
 
 I do not think that is fair.
 
@@ -127,13 +117,9 @@ I do not think that is fair.
 
 One of my concerns with fully remote employment is that the development curve can become remarkably flat.
 
-A person joins a company and learns a great deal at first. They have to understand the systems, people, products, and immediate responsibilities of the role. There is an initial burst of development because nearly everything is new.
+A person joins a company and learns a great deal at first. They have to understand the systems, people, products, and immediate responsibilities of the role. There is an initial burst of development because nearly everything is new. Then the curve begins to level out.
 
-Then the curve begins to level out.
-
-They continue to become more efficient at the work already assigned to them, but they receive much less exposure to adjacent areas. They may become better at that particular job inside that particular company without becoming significantly broader in their trade or more commercially capable.
-
-Their world becomes the work directed towards them.
+They continue to become more efficient at the work already assigned to them, but they receive much less exposure to adjacent areas. They may become better at that particular job inside that particular company without becoming significantly broader in their trade or more commercially capable. Their world becomes the work directed towards them.
 
 In that situation, moving to another company can become one of their largest development events. Suddenly there is a new set of systems, people, expectations, and problems. Their learning accelerates again because the environment has changed.
 
@@ -141,9 +127,7 @@ That is not necessarily bad. Moving between companies has always been an importa
 
 The problem is when changing employer becomes one of the only reliable ways to achieve meaningful breadth.
 
-When you work in an office full of people, you are passively developing all the time. You encounter ideas, professions, problems, and perspectives beyond your immediate responsibility. You learn your own trade, but you also learn enough about the work around it to become more effective.
-
-You begin to understand finance, sales, people management, operations, and customers through exposure rather than a formal course.
+When you work in an office full of people, you are passively developing all the time. You encounter ideas, professions, problems, and perspectives beyond your immediate responsibility. You learn your own trade, but you also learn enough about the work around it to become more effective. You begin to understand finance, sales, people management, operations, and customers through exposure rather than a formal course.
 
 Remote work can make a job narrower without anybody consciously choosing to narrow it.
 
@@ -163,9 +147,7 @@ That matters when work becomes difficult or urgent. Teams that know one another 
 
 Before COVID, I experienced tightly connected teams that could move at remarkable speed.
 
-People shared context almost continuously. Problems were surfaced early. Knowledge travelled quickly. The distinction between working and learning was often invisible because both were happening at the same time.
-
-I have not been able to recreate those dynamics fully since COVID.
+People shared context almost continuously. Problems were surfaced early. Knowledge travelled quickly. The distinction between working and learning was often invisible because both were happening at the same time. I have not been able to recreate those dynamics fully since COVID.
 
 Remote tools have improved enormously. Disciplined distributed teams can do excellent work. I work for a global company and rely on those tools every day. Geography gives us access to people and expertise that would otherwise be unavailable.
 
@@ -181,11 +163,7 @@ We should be honest about that rather than pretending every working arrangement 
 
 The language around hybrid work has become unhelpfully vague.
 
-A company can describe almost any arrangement as hybrid. People may work all over the country, visit an office occasionally, and meet once a week on a video call. A globally distributed team may gather in person every six months. Another team may attend a building on different days and rarely see one another.
-
-That is not the model I am describing.
-
-I am talking about an in-office team that is allowed to work from home twice a week.
+A company can describe almost any arrangement as hybrid. People may work all over the country, visit an office occasionally, and meet once a week on a video call. A globally distributed team may gather in person every six months. Another team may attend a building on different days and rarely see one another. That is not the model I am describing. I am talking about an in-office team that is allowed to work from home twice a week.
 
 The centre of gravity is the office. The team spends most of the working week together. Home working provides flexibility around that shared rhythm rather than replacing it.
 
@@ -195,9 +173,7 @@ Those office days are coordinated. This matters.
 
 Five people who each attend the office on a different day have not formed an office-based team. They have simply changed the location from which they work alone.
 
-For a while, I encouraged people to spend time in the office. I no longer merely encourage it. For people working locally on my team, I require three days out of five together.
-
-I make that requirement because I believe it creates better conditions for learning, development, relationships, and long-term team performance.
+For a while, I encouraged people to spend time in the office. I no longer merely encourage it. For people working locally on my team, I require three days out of five together. I make that requirement because I believe it creates better conditions for learning, development, relationships, and long-term team performance.
 
 It is not a rejection of flexibility. I value flexibility and use it myself.
 
@@ -209,9 +185,7 @@ I also reject the argument that every day in the office needs to be carefully pr
 
 If a globally distributed team meets in person once every six months, or worse, once a year, then of course you should make the most of it.
 
-Plan the time carefully. Bring the right people together. Have the difficult conversations, build the relationships, and squeeze as much value as possible from a scarce opportunity.
-
-That is not the same thing as regularly working together in an office.
+Plan the time carefully. Bring the right people together. Have the difficult conversations, build the relationships, and squeeze as much value as possible from a scarce opportunity. That is not the same thing as regularly working together in an office.
 
 When people are together three days a week, every week, the greatest gift is simply that they are there.
 
@@ -239,9 +213,7 @@ There will be days when I spend much of my time on calls with people elsewhere i
 
 I am still available to the people around me before the call, after it, and in the gaps between. I still overhear, notice, answer, ask, and contribute. So do they.
 
-The test of an office day should not be whether every hour contained an activity that could only have happened in person.
-
-That sets an absurd standard we never applied before COVID.
+The test of an office day should not be whether every hour contained an activity that could only have happened in person. That sets an absurd standard we never applied before COVID.
 
 The value is in making shared presence normal again. Once it is normal, the valuable moments stop needing to be engineered.
 
@@ -263,15 +235,9 @@ Working together in person accelerates learning, creates broader context, streng
 
 Those benefits are real too.
 
-My job as a leader is not simply to choose the arrangement people find most convenient at this exact moment. It is to create the conditions in which people, teams, and the organisation can become better over time.
+My job as a leader is not simply to choose the arrangement people find most convenient at this exact moment. It is to create the conditions in which people, teams, and the organisation can become better over time. That requires thinking beyond immediate output. It requires asking whether people are developing towards their potential, whether knowledge is travelling across the team, and whether younger employees are being given a fair opportunity to learn how work actually works.
 
-That requires thinking beyond immediate output.
-
-It requires asking whether people are developing towards their potential, whether knowledge is travelling across the team, and whether younger employees are being given a fair opportunity to learn how work actually works.
-
-Most importantly, we have a responsibility not to offer younger people convenience at the expense of their development.
-
-They deserve the chance to build the breadth of knowledge, confidence, and relationships that many of us acquired by being surrounded by working life.
+Most importantly, we have a responsibility not to offer younger people convenience at the expense of their development. They deserve the chance to build the breadth of knowledge, confidence, and relationships that many of us acquired by being surrounded by working life.
 
 After trying the alternatives, I believe that requires spending a meaningful part of the week together.
 

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -154,7 +154,7 @@ const blogPostingJsonLd = {
         </div>
       </header>
       
-      {showToc && <TableOfContents headings={headings} variant="inline" />}
+      {showToc && <TableOfContents headings={headings} variant="inline" maxDepth={3} />}
 
       <div class="prose prose-lg max-w-none">
         <slot />
@@ -162,7 +162,7 @@ const blogPostingJsonLd = {
     </div>
       {showToc && (
         <aside class="hidden lg:sticky lg:top-8 lg:block lg:max-h-[calc(100vh-4rem)] lg:overflow-y-auto">
-          <TableOfContents headings={headings} variant="sidebar" />
+          <TableOfContents headings={headings} variant="sidebar" maxDepth={3} />
         </aside>
       )}
     </div>

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -1,7 +1,8 @@
 ---
 import Base from './Base.astro';
 import { Image } from 'astro:assets';
-import type { ImageMetadata } from 'astro';
+import type { ImageMetadata, MarkdownHeading } from 'astro';
+import TableOfContents from '../components/TableOfContents.astro';
 
 export interface Props {
   title: string;
@@ -15,6 +16,8 @@ export interface Props {
   readingTime?: number;
   image?: ImageMetadata;
   markdownPath?: string;
+  headings?: MarkdownHeading[];
+  toc?: boolean;
 }
 
 const {
@@ -28,8 +31,13 @@ const {
   canonical,
   readingTime,
   image,
-  markdownPath
+  markdownPath,
+  headings = [],
+  toc = false
 } = Astro.props;
+
+// The contents column only earns its space on posts with several sections.
+const showToc = toc && headings.filter((heading) => heading.depth === 2).length > 1;
 
 
 const formatDate = (date: Date) => {
@@ -82,7 +90,17 @@ const blogPostingJsonLd = {
   articleModifiedTime={(updated ?? date).toISOString()}
   jsonLd={blogPostingJsonLd}
 >
-  <article class="mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 py-12">
+  <article
+    class:list={[
+      'mx-auto px-4 sm:px-6 lg:px-8 py-12',
+      showToc ? 'max-w-6xl' : 'max-w-4xl'
+    ]}
+  >
+    <div
+      class:list={[
+        showToc && 'lg:grid lg:grid-cols-[minmax(0,1fr)_15rem] lg:items-start lg:gap-x-12'
+      ]}
+    >
     <div class="max-w-3xl">
       <header class="mb-8">
         {image && (
@@ -136,9 +154,17 @@ const blogPostingJsonLd = {
         </div>
       </header>
       
+      {showToc && <TableOfContents headings={headings} variant="inline" />}
+
       <div class="prose prose-lg max-w-none">
         <slot />
       </div>
+    </div>
+      {showToc && (
+        <aside class="hidden lg:sticky lg:top-8 lg:block lg:max-h-[calc(100vh-4rem)] lg:overflow-y-auto">
+          <TableOfContents headings={headings} variant="sidebar" />
+        </aside>
+      )}
     </div>
   </article>
 </Base>

--- a/src/pages/writing/[...slug].astro
+++ b/src/pages/writing/[...slug].astro
@@ -15,7 +15,7 @@ export async function getStaticPaths() {
 const { post } = Astro.props;
 
 // Render content
-const { Content } = await render(post);
+const { Content, headings } = await render(post);
 
 // Calculate reading time from the post body
 const readingStats = readingTime(post.body ?? '');
@@ -34,6 +34,8 @@ const readingTimeMinutes = Math.ceil(readingStats.minutes);
   readingTime={readingTimeMinutes}
   image={post.data.image}
   markdownPath={`/writing/${post.id}.md`}
+  headings={headings}
+  toc={post.data.toc}
 >
   <Content components={{ ArticleLink }} />
 </Post>


### PR DESCRIPTION
Two linked articles.

**The Rules I Try to Do Business By** collects rules on service business systems and teams, grouped into themes.

**Working From Home Holds Your Learning Back** started as one section of the above, grew too big to sit inside it, and is now its own piece. The two cross-reference each other. I have also added a research addendum citing nine studies.

Also adds an opt-in table of contents component. It generates itself from a post's headings, so it cannot go stale: sticky sidebar on large screens, collapsed block on small ones, current section highlighted as you read. Enabled per post with `toc: true`, and the widened two-column layout only applies when a ToC is shown.