### PR TITLE
Add “Name things for what they do” (Ronseal naming) rule to business post

### DIFF
--- a/src/content/posts/the-rules-i-try-to-do-business-by.mdx
+++ b/src/content/posts/the-rules-i-try-to-do-business-by.mdx
@@ -67,6 +67,56 @@ Those distinctions may matter greatly to you. They probably do not matter at all
 
 Customers should be able to describe the outcome they need. It is your job to work out what happens next.
 
+### Name things for what they do
+
+I am a big believer in what I tend to call **Ronseal naming**.
+
+For anyone who somehow missed decades of British advertising, Ronseal's line is: *"It does exactly what it says on the tin."*
+
+That is also, in my view, an excellent naming strategy.
+
+If you build a product, service, team, tool, portal, dashboard, process, or pretty much anything else, give it a name which tells people what it actually does.
+
+This sounds almost insultingly obvious, yet organisations seem to have an extraordinary instinct to do the opposite.
+
+We invent clever names, acronyms, internal brands, mythological references, and project names which escape into production. Words which sounded exciting in the workshop where six people spent three weeks designing the thing.
+
+Then everyone else has to learn what they mean.
+
+I think that is backwards.
+
+A good name should work at a drive-by glance. Someone should see it in a menu, hear it mentioned in a conversation, spot it in Slack six months later, and have a pretty good idea what it is.
+
+If I need somewhere to request a laptop, **Request a Laptop** is a fantastically good name.
+
+If I need to see how much holiday I have left, **Holiday Balance** is a fantastically good name.
+
+Neither will win an award from a branding agency. Both will win repeatedly at the much more important task of people being able to find the bloody thing.
+
+There is another benefit too: Ronseal names are remarkably memorable.
+
+Humans are quite good at reconstructing obvious names. I might not remember exactly what your internal tool was called, but if I know it checks supplier contracts and you had the good sense to call it **Supplier Contract Checker**, I have a reasonable chance of finding it again.
+
+Call it *Athena*, *Nexus*, *Project Lighthouse*, or *C360* and now I have to remember a piece of arbitrary organisational trivia forever.
+
+That is needless friction.
+
+And, as with so many of these rules, each individual bit of friction looks tiny. Nobody is going to file a complaint because they spent thirty seconds trying to remember what the expenses system is called.
+
+But multiply that across hundreds or thousands of people, dozens of systems, and years of work and you have created an organisation where simply **knowing what things are called** becomes institutional knowledge.
+
+That is particularly hostile to new starters. The people who have been around for five years know that *Phoenix* is where you request software access. Everybody else quite reasonably assumes it is either an insurance company or something involving Harry Potter.
+
+There are obviously occasions where you are genuinely building a brand. Brands can earn meaning over time. Nobody expects the name *Google* to literally describe an internet search engine.
+
+But most things inside a business are not brands, however much we sometimes enjoy pretending that they are.
+
+They are tools. They have jobs. Name them after the job!
+
+My test is simple: **if somebody who has never seen the thing before can make a decent guess at what it does from the name alone, you have probably named it well.**
+
+It should do exactly what it says on the tin, and the tin should say exactly what it does. Thanks, Ronseal.
+
 ### Be the customer
 
 Do you ever think about what it's like to use your services? No, really though, do you ever actually go and use your services yourself?


### PR DESCRIPTION
### Motivation

- Reduce discoverability friction by encouraging descriptive, job-focused names for internal tools and services.  
- Capture a succinct guideline (the “Ronseal naming” test) so teams pick names that are obvious and memorable rather than branded or cryptic.  
- Place the guidance next to existing customer/service rules so naming is considered part of making services easy to use.

### Description

- Added a new section titled `### Name things for what they do` to `src/content/posts/the-rules-i-try-to-do-business-by.mdx` immediately after the guidance about customers describing outcomes.  
- The new copy introduces “Ronseal naming”, explains why descriptive names reduce organisational friction, gives practical examples (`Request a Laptop`, `Holiday Balance`, `Supplier Contract Checker`), and notes when genuine branding is the exception.  
- Ran code formatting on the updated post to align with the repository style rules (Prettier adjustments applied).

### Testing

- Ran formatting: `npx prettier --check` and `npx prettier --write` to normalise the new content; formatting issues were fixed by `--write`. (succeeded)  
- Ran static checks: `npm run typecheck` (executed under Node 22 during verification) produced expected warnings about some deprecated MDX/remark usage but completed without blocking errors. (succeeded with informational warnings)  
- Ran lint: `npm run lint` completed without errors. (succeeded)  
- Built the site: `npm run build` (Astro static build) completed and produced the expected routes. (succeeded)  
- Render verification: captured a rendered-page screenshot of the updated article using Playwright and saved it to `/tmp/ronseal-section.png`. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c93e3a5388329ac4535cc4bacd165)