### PR TITLE
Group and slow Dependabot updates and auto-merge low-risk bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,23 +3,21 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 14
     groups:
-      astro:
-        patterns:
-          - "astro"
-          - "@astrojs/*"
-      eslint:
-        patterns:
-          - "eslint*"
-          - "typescript-eslint"
-          - "@eslint/*"
-      tailwind:
-        patterns:
-          - "tailwindcss"
-          - "@tailwindcss/*"
+      # Ships to the built site, so these are reviewed by hand.
+      production:
+        applies-to: version-updates
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      # Lint, types and build scripts only, never reaches the output.
+      development:
+        applies-to: version-updates
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
+    # Majors match no group, so they still arrive as individual pull requests.
     ignore:
       # TypeScript 6 blocked until @astrojs/check supports it
       - dependency-name: "typescript"
@@ -28,6 +26,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     cooldown:
-      default-days: 7
+      default-days: 14
+    groups:
+      actions:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+    - name: Fetch Dependabot metadata
+      id: meta
+      uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    # Patch bumps anywhere, plus minor bumps to tooling that never ships to the
+    # site. Production minors and every major still wait for a human.
+    - name: Enable auto-merge
+      if: >
+        steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+        (steps.meta.outputs.update-type == 'version-update:semver-minor' &&
+         steps.meta.outputs.dependency-type == 'direct:development')
+      run: gh pr merge --auto --squash "$PR_URL"
+      env:
+        PR_URL: ${{ github.event.pull_request.html_url }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Dependency bumps were about 80% of merge traffic (23 bot PRs against 6 human ones in August), and because every ungrouped npm PR touches `package-lock.json`, merging one conflicts the rest.

- Group npm minor and patch updates into a production PR and a development PR, which also removes the lockfile rebase cascade. Majors match no group, so they still arrive individually.
- Group GitHub Actions minor and patch updates the same way.
- Move both ecosystems from weekly to monthly and raise the cooldown from 7 to 14 days, so point-release churn collapses into one bump.
- Auto-merge patch bumps, and minor bumps to devDependencies, once CI is green. Production minors and all majors still wait for review.

Dependabot security alerts are being enabled separately, so vulnerability fixes stay immediate and no longer depend on the version-update cadence.